### PR TITLE
fix a bug in extracting samples with no beacon/wifi data introduced in 59bc300

### DIFF
--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -149,7 +149,7 @@ def extract_samples_ble_wifi_other(samples):
             s2 = copy.copy(s)
             s2["data"]["beacons"] = s2_wifi
             samples_wifi.append(s2)
-        if len(s2_ble) == 0 and len(s2_wifi):
+        if len(s2_ble) == 0 and len(s2_wifi) == 0:
             s2 = copy.copy(s)
             samples_other.append(s2)
 


### PR DESCRIPTION
Fixed a bug that multi_floor_manager failed to create an area_classifier instance when sample data have no beacon or WiFi information. This bug was introduced in 59bc300.