### PR TITLE
fix deadlock caused by localization being completed before the functi…

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -314,6 +314,15 @@ eval $com2
 dcpid=($!)
 blue "[$dcpid] $dccom up $( echo "$(date +%s.%N) - $start" | bc -l )"
 
+if [[ $run_test -eq 1 ]]; then
+    blue "Running test $module $test_regex"
+    if [[ $debug -eq 1 ]]; then
+        docker compose -f docker-compose-debug.yaml run debug /home/developer/ros2_ws/script/run_test.sh -w -d $module $test_regex $retryoption # debug
+    else
+        docker compose run --rm navigation /home/developer/ros2_ws/script/run_test.sh -w $module $test_regex $retryoption
+    fi
+    ctrl_c $?
+fi
 
 while [[ $launched -lt 5 ]]; do
     snore 1
@@ -321,16 +330,6 @@ while [[ $launched -lt 5 ]]; do
 done
 
 blue "All launched: $( echo "$(date +%s.%N) - $start" | bc -l )"
-
-if [[ $run_test -eq 1 ]]; then
-    blue "Running test $module $test_regex"
-    if [[ $debug -eq 1 ]]; then
-        docker compose -f docker-compose-debug.yaml run debug /home/developer/ros2_ws/script/run_test.sh -w -d $module $test_regex $retryoption # debug
-    else
-        docker compose exec navigation /home/developer/ros2_ws/script/run_test.sh -w $module $test_regex $retryoption
-    fi
-    ctrl_c $?
-fi
 
 while [ 1 -eq 1 ];
 do


### PR DESCRIPTION
テストのシミュレーション起動時（`./launch.sh -s -t`）にready状態にならないという問題が発生しました。
例えば、cabot_sites_cmuのtests.pyのwait_ready関数において、`tester.wait_localization_started()`が呼ばれるときには位置推定が完了してしまい、処理が進まなくなっているようです。
こちらの現象はクフウシヤで使用しているGPU入りのPCで発生しました。

そこで、`./launch.sh`のdocker実行の処理順序の入れ替えと`docker compose exec`から`docker compose run`に変更して対処しました。

ご確認の程お願いいたします。