### PR TITLE
fix simulator issues on GPU servers by adding env variables

### DIFF
--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -51,6 +51,9 @@ services:
       - CYCLONEDDS_NETWORK_INTERFACE_NAME
       - CYCLONEDDS_NETWORK_INTERFACE_AUTODETERMINE # set automatically by launch.sh
       - ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY:-false}
+      - ROS_DOMAIN_ID
+      - __NV_PRIME_RENDER_OFFLOAD
+      - __GLX_VENDOR_LIBRARY_NAME
     volumes:
 # bridge - if DDS use shared memory
       - /dev/shm:/dev/shm
@@ -168,6 +171,7 @@ services:
       - CYCLONEDDS_URI
       - CYCLONEDDS_NETWORK_INTERFACE_NAME
       - CYCLONEDDS_NETWORK_INTERFACE_AUTODETERMINE # set automatically by launch.sh
+      - ROS_DOMIN_ID
     volumes:
       - /dev:/dev
       - /sys/devices:/sys/devices

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -171,7 +171,7 @@ services:
       - CYCLONEDDS_URI
       - CYCLONEDDS_NETWORK_INTERFACE_NAME
       - CYCLONEDDS_NETWORK_INTERFACE_AUTODETERMINE # set automatically by launch.sh
-      - ROS_DOMIN_ID
+      - ROS_DOMAIN_ID
     volumes:
       - /dev:/dev
       - /sys/devices:/sys/devices


### PR DESCRIPTION
Fix issues when running a simulator on remote GPU server by adding `__NV_PRIME_RENDER_OFFLOAD` and `__GLX_VENDOR_LIBRARY_NAME` in `docker-compose-common.yaml` .
Without setting these values, the simulator won't use GPUs for simulation, and it makes lidar simulation very slow (2~3Hz).

These values can be set in `.env` file, and I added some descriptions about these values in readme in cabot repository (please see PR https://github.com/CMU-cabot/cabot/pull/167 )