### PR TITLE
fix tf speed control

### DIFF
--- a/cabot/config/cabot-control.yaml
+++ b/cabot/config/cabot-control.yaml
@@ -76,7 +76,7 @@ cabot:
       speed_input: ['/cabot/user_speed', '/cabot/lidar_speed', '/cabot/people_speed', '/cabot/tf_speed', '/cabot/queue_speed', '/cabot/map_speed', '/cabot/touch_speed_switched']
       speed_limit: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
       speed_timeout: [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.5]
-      complete_stop: [false,false,false,false,true,false,true]
+      complete_stop: [false,false,false,true,true,false,true]
       configurable: [true,false,false,false,false,false,false]
 
   speed_control_node_touch_false:  #TODO better way
@@ -86,7 +86,7 @@ cabot:
       speed_input: ['/cabot/user_speed', '/cabot/lidar_speed', '/cabot/people_speed', '/cabot/tf_speed', '/cabot/queue_speed', '/cabot/map_speed']
       speed_limit: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
       speed_timeout: [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.5]
-      complete_stop: [false,false,false,false,true,false,true]
+      complete_stop: [false,false,false,true,true,false,true]
       configurable: [true,false,false,false,false,false,false]
 
   ekf_node:

--- a/cabot/src/safety/tf_speed_control_node.cpp
+++ b/cabot/src/safety/tf_speed_control_node.cpp
@@ -50,8 +50,8 @@ public:
   : rclcpp::Node("tf_speed_control_node", options),
     limit_topic_("tf_limit"),
     max_speed_(1.0),
-    check_rate_(1.0),
-    tf_timeout_(1.0),
+    check_rate_(5.0),
+    tf_timeout_(0.2),
     map_frame_("map"),
     robot_base_frame_("base_footprint")
   {


### PR DESCRIPTION
Summary of changes
- Fixed a bug in which tf_speed_control did not work when TF update was stopped.
- Also modified the default behavior of tf_speed_control for improving safety
    - increase tf check frequency and decrease tf timeout to quickly detect tf disconnections
    - apply complete stop when tf is disconnected

These changes were tested on a physical robot (cabot3-ace2)