### PR TITLE
fix mf_localization_mapping to correctly convert esp32 wifi scans

### DIFF
--- a/mf_localization_mapping/launch/includes/esp32_cartographer.launch.xml
+++ b/mf_localization_mapping/launch/includes/esp32_cartographer.launch.xml
@@ -27,5 +27,6 @@
     <param name="touch_params" value="[128,64,24]" /> <!-- dummy param to avoid error -->
     
     <remap from="/imu" to="/imu/data" />
+    <remap from="/wifi" to="/esp32/wifi_scan_str" />
   </node>
 </launch>

--- a/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
+++ b/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
@@ -162,10 +162,16 @@ def generate_launch_description():
                 }.items(),
                 condition=IfCondition(use_velodyne)
             ),
+            # launch esp32 wifi receiver when esp32 is used as a primary micro controller
             IncludeLaunchDescription(
-                AnyLaunchDescriptionSource(PathJoinSubstitution([get_package_share_directory('wireless_scanner_ros'), 'launch', 'wifi_ble_receiver.launch'])),
-                condition=IfCondition(record_wireless)
+                AnyLaunchDescriptionSource(PathJoinSubstitution([get_package_share_directory('wireless_scanner_ros'), 'launch', 'esp32_receiver.launch.xml'])),
+                condition=IfCondition(AndSubstitution(record_wireless, use_esp32))
             ),
+            # ble_receiver will be launched by ble_scan service
+            # IncludeLaunchDescription(
+            #     AnyLaunchDescriptionSource(PathJoinSubstitution([get_package_share_directory('wireless_scanner_ros'), 'launch', 'ble_receiver.launch.xml'])),
+            #     condition=IfCondition(record_wireless)
+            # ),
 
             OpaqueFunction(
                 function=configure_ros2_bag_arguments,


### PR DESCRIPTION
Fixed a bug in which esp32 wifi scan (/esp32/wifi_scan_str topic) was not converted to /esp32/wifi topic when mapping while using ESP32 as a primary micro-controller.