### PR TITLE
add depend people_msgs to pedestrian_plugin_msgs package

### DIFF
--- a/pedestrian_plugin_msgs/package.xml
+++ b/pedestrian_plugin_msgs/package.xml
@@ -32,6 +32,7 @@
 
   <depend>rosidl_default_generators</depend>
   <depend>rosidl_default_runtime</depend>
+  <depend>people_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
cabot-ros2を68276a2から更新してhost_wsでcolcon buildをすると以下のエラーが出た

(people関連だと思って)石原さんにみて頂いたところ、people_msgsの依存指定が必要だったようです

```
Starting >>> people_msgs
Starting >>> cabot_msgs
Starting >>> cabot_debug
Starting >>> mf_localization_msgs
Starting >>> odriver_msgs
Starting >>> pedestrian_plugin_msgs
Starting >>> tf_bag
Starting >>> track_people_msgs
--- stderr: pedestrian_plugin_msgs                                                                                                                                                    
CMake Error at CMakeLists.txt:7 (find_package):
  By not providing "Findpeople_msgs.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "people_msgs", but CMake did not find one.

  Could not find a package configuration file provided by "people_msgs" with
  any of the following names:

    people_msgsConfig.cmake
    people_msgs-config.cmake

  Add the installation prefix of "people_msgs" to CMAKE_PREFIX_PATH or set
  "people_msgs_DIR" to a directory containing one of the above files.  If
  "people_msgs" provides a separate development package or SDK, be sure it
  has been installed.


---
Failed   <<< pedestrian_plugin_msgs [0.32s, exited with code 1]
Aborted  <<< cabot_debug [0.33s]
Aborted  <<< odriver_msgs [0.33s]
Aborted  <<< people_msgs [0.36s]
Aborted  <<< cabot_msgs [0.36s]
Aborted  <<< mf_localization_msgs [0.41s]                                                                                                  
Aborted  <<< track_people_msgs [0.42s]
Aborted  <<< tf_bag [0.55s]
```