### PR TITLE
fix incorrect robot coordinate used for collision detection in walk_sfm.py

### DIFF
--- a/pedestrian_plugin/pedestrian/walk_sfm.py
+++ b/pedestrian_plugin/pedestrian/walk_sfm.py
@@ -65,7 +65,7 @@ def onUpdate(**args):
 
     if robot:
         rx = robot['x']
-        ry = robot['z']
+        ry = robot['y']
         x = args['x']
         y = args['y']
         dx = rx - x


### PR DESCRIPTION
[pedestrian_pluginのwalk_sfm.py](https://github.com/CMU-cabot/cabot-navigation/blob/e5830279e551acd4bf1b4ab1bf0c00ba0779ed01/pedestrian_plugin/pedestrian/walk_sfm.py#L68)の衝突判定に使用するロボットの座標がy座標となるべきところがz座標となっていたため、修正しました。
ご確認の程お願いいたします。