### PR TITLE
add a controller config for teleop_gamepad in cabot_ui

### DIFF
--- a/cabot_ui/config/cabot2-common-mapping.yaml
+++ b/cabot_ui/config/cabot2-common-mapping.yaml
@@ -43,3 +43,21 @@ cabot:
         yaw: 1.0
       enable_button: 4  # L1 shoulder button
       enable_turbo_button: 5  # R1 shoulder button
+
+  # Xbox Series X/S Wireless Controller (Bluetooth Connection)
+  teleop_twist_joy_xs:
+    ros__parameters:
+      axis_linear: # left joy up/down
+        x: 1
+      scale_linear:
+        x: 0.4
+      scale_linear_turbo:
+        x: 0.7
+      axis_angular: # right joy left/right
+        yaw: 2
+      scale_angular:
+        yaw: 1.0
+      scale_angular_turbo:
+        yaw: 1.5
+      enable_button: 6  # L1 shoulder button
+      enable_turbo_button: 7  # R1 shoulder button


### PR DESCRIPTION
Add /joy to /cmd_vel mapping config for Xbox Series X/S Wireless Controller (Bluetooth Connection)

Although I'm not sure which ros package (cabot_base or cabot_ui?) I should add this change, I did it in cabot_ui package.

Expected gamepad: Xbox Series X/S Wireless Controller
Connection: Bluetooth connection

Usage:
```
ros2 launch cabot_ui teleop_gamepad.launch.py gamepad:=xs
```