### PR TITLE
fix localization/Dockerfile to prevent orjson build error

### DIFF
--- a/docker/localization/Dockerfile
+++ b/docker/localization/Dockerfile
@@ -86,7 +86,7 @@ RUN apt update && \
 RUN pip install --no-cache-dir \
     requests \
     certifi \
-    orjson \
+    orjson==3.10.6 \
     pyproj \
     rosbags
 


### PR DESCRIPTION
Fix localization/Dockerfile to prevent orjson build error.
`pip3 install orjson` fails after the recent update of orjson v 3.10.7 released today August 9, 2024.
This change specifies orjson==3.10.6 as a quickfix

```
Collecting orjson
  ...
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      
      Cargo, the Rust package manager, is not installed or is not on PATH.
      This package requires Rust and Cargo to compile extensions. Install it through
      the system's package manager or via https://rustup.rs/
      
      Checking for Rust toolchain....
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```