### PR TITLE
Fix mapping post processing with hesai lidar

### DIFF
--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -402,6 +402,14 @@ if [ $cart_mapping -eq 1 ]; then
         fi
     fi
 
+    # define and switch record_points variable
+    record_points=false  # VLP-16
+    if [ $gazebo -eq 1 ]; then
+        record_points=true
+    elif [ "${LIDAR_MODEL}" != "VLP16" ]; then
+        record_points=true
+    fi
+
     # find robot description from cabot_description package
     robot_desc_pkg_share_dir=`ros2 pkg prefix --share cabot_description`
     robot_xacro=$robot_desc_pkg_share_dir/robots/$robot.urdf.xacro.xml
@@ -422,7 +430,7 @@ if [ $cart_mapping -eq 1 ]; then
           record_wireless:=true \
           save_samples:=true \
           record_required:=true \
-          record_points:=$gazebo_bool \
+          record_points:=$record_points \
           use_xsens:=${USE_XSENS:-true} \
           use_arduino:=${USE_ARDUINO:-false} \
           use_esp32:=${USE_ESP32:-false} \

--- a/cabot_mf_localization/script/mapping_post_process.sh
+++ b/cabot_mf_localization/script/mapping_post_process.sh
@@ -25,18 +25,23 @@ WORKDIR=/home/developer/post_process
 QUIT_WHEN_ROSBAG_FINISH=${QUIT_WHEN_ROSBAG_FINISH:-true}
 PLAYBAG_RATE_CARTOGRAPHER=${PLAYBAG_RATE_CARTOGRAPHER:-1.0}
 PLAYBAG_RATE_PC2_CONVERT=${PLAYBAG_RATE_PC2_CONVERT:-1.0}
+LIDAR_MODEL=${LIDAR_MODEL:-VLP16}
 
 gazebo=${PROCESS_GAZEBO_MAPPING:-0}
 
 # topic
 points2_topic='/velodyne_points'
 imu_topic=/imu/data
-convert_points=true
+convert_points=true  # VLP16 (default LIDAR_MODEL)
 
 if [[ $gazebo -eq 1 ]]; then
     imu_topic=/cabot/imu/data
     convert_points=false
+elif [ "${LIDAR_MODEL}" != "VLP16" ]; then
+    convert_points=false
 fi
+
+echo "LIDAR_MODEL=$LIDAR_MODEL"
 
 function blue {
     echo -en "\033[36m"  ## blue

--- a/mf_localization_mapping/launch/includes/xsens_driver_cartographer.launch.py
+++ b/mf_localization_mapping/launch/includes/xsens_driver_cartographer.launch.py
@@ -36,7 +36,8 @@ def generate_launch_description():
             name='xsens_mti_node',
             output='screen',
             parameters=[parameters_file_path, {
-                "frame_id": "imu"
+                "frame_id": "imu",
+                "pub_transform": False
             }],
             arguments=[]
         )


### PR DESCRIPTION
This pull request is opened for fixing a bug remained in pull request #54.

In #54, `-L` option to specify LIDAR_MODEL was added to `mapping-launch.sh` script to enable mapping with lidar sensors other than VLP16 (XT16 or XT32).
It works with realtime mapping option (e.g. `./mapping-launch.sh -e -L XT16 -c`) but it does not work with post processing (`./mapping-launch.sh -e -L XT16` then `./mapping-launch.sh -p PATH_TO_BAG_FILE`) because pointcloud data (`/velodyne_points`) is not recorded to the bag file.
This pull request fixes the issue.

It was confirmed that post processing worked with `-L XT16` option. (`./mapping-launch.sh -e -L XT16` then `./mapping-launch.sh -L XT16 -p PATH_TO_BAG_FILE`)


