### PR TITLE
move touch speed control function from cabot-driver/cabot_serial to cabot/safety

### DIFF
--- a/cabot/CMakeLists.txt
+++ b/cabot/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(safety_nodes SHARED
   src/safety/people_speed_control_node.cpp
   src/safety/speed_control_node.cpp
   src/safety/tf_speed_control_node.cpp
+  src/safety/touch_speed_control_node.cpp
   src/safety/util.cpp
 )
 
@@ -115,6 +116,11 @@ rclcpp_components_register_node(
   safety_nodes
   PLUGIN "CaBotSafety::TFSpeedControlNode"
   EXECUTABLE tf_speed_control_node
+)
+rclcpp_components_register_node(
+  safety_nodes
+  PLUGIN "CaBotSafety::TouchSpeedControlNode"
+  EXECUTABLE touch_speed_control_node
 )
 
 if(BUILD_TESTING)

--- a/cabot/config/cabot-control.yaml
+++ b/cabot/config/cabot-control.yaml
@@ -69,6 +69,10 @@ cabot:
     ros__parameters:
       limit_topic: /cabot/tf_speed
 
+  touch_speed_control_node:
+    ros__parameters:
+      touch_speed_max_inactive: 0.5
+
   speed_control_node_touch_true:
     ros__parameters:
       cmd_vel_input: /cabot/cmd_vel_adapter

--- a/cabot/include/cabot/touch_speed_control_node.hpp
+++ b/cabot/include/cabot/touch_speed_control_node.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2024  Carnegie Mellon University
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef CABOT__TOUCH_SPEED_CONTROL_NODE_HPP_
+#define CABOT__TOUCH_SPEED_CONTROL_NODE_HPP_
+
+#include <rclcpp/node.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/int16.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+namespace CaBotSafety
+{
+class TouchSpeedControlNode : public rclcpp::Node
+{
+public:
+  explicit TouchSpeedControlNode(const rclcpp::NodeOptions & options);
+  ~TouchSpeedControlNode() = default;
+
+private:
+  static void signalHandler(int signal);
+  void touch_callback(std_msgs::msg::Int16::SharedPtr msg);
+  void set_touch_speed_active_mode(
+    const std_srvs::srv::SetBool::Request::SharedPtr req,
+    std_srvs::srv::SetBool::Response::SharedPtr res);
+
+  bool touch_speed_active_mode_;
+  double touch_speed_max_speed_;
+  double touch_speed_max_speed_inactive_;
+
+  rclcpp::Subscription<std_msgs::msg::Int16>::SharedPtr touch_sub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr touch_speed_switched_pub_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_touch_speed_active_mode_srv;
+};
+}
+
+#endif  // CABOT__TOUCH_SPEED_CONTROL_NODE_HPP_

--- a/cabot/include/cabot/touch_speed_control_node.hpp
+++ b/cabot/include/cabot/touch_speed_control_node.hpp
@@ -49,6 +49,7 @@ private:
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr touch_speed_switched_pub_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_touch_speed_active_mode_srv;
 };
-}
+
+}  // namespace CaBotSafety
 
 #endif  // CABOT__TOUCH_SPEED_CONTROL_NODE_HPP_

--- a/cabot/launch/cabot_control.launch.py
+++ b/cabot/launch/cabot_control.launch.py
@@ -180,7 +180,7 @@ def generate_launch_description():
             output=output,
             parameters=[*param_files, {'use_sim_time': use_sim_time}],
         ),
-        # Cabot People SPeed Control
+        # Cabot People Speed Control
         Node(
             package='cabot',
             executable='people_speed_control_node',
@@ -195,6 +195,15 @@ def generate_launch_description():
             executable='tf_speed_control_node',
             namespace='/cabot',
             name='tf_speed_control_node',
+            output=output,
+            parameters=[*param_files, {'use_sim_time': use_sim_time}],
+        ),
+        # Cabot Touch Speed Control
+        Node(
+            package='cabot',
+            executable='touch_speed_control_node',
+            namespace='/cabot',
+            name='touch_speed_control_node',
             output=output,
             parameters=[*param_files, {'use_sim_time': use_sim_time}],
         ),

--- a/cabot/src/safety/touch_speed_control_node.cpp
+++ b/cabot/src/safety/touch_speed_control_node.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2024  Carnegie Mellon University
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <csignal>
+#include <string>
+#include <algorithm>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <functional>
+
+#include "cabot/touch_speed_control_node.hpp"
+
+using namespace std::chrono_literals;
+
+namespace CaBotSafety
+{
+TouchSpeedControlNode::TouchSpeedControlNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("touch_speed_control_node", rclcpp::NodeOptions(options).use_intra_process_comms(false)),
+  touch_speed_active_mode_(true),
+  touch_speed_max_speed_(2.0),
+  touch_speed_max_speed_inactive_(0.5)
+{
+  // use_intra_process_comms is currently not supported
+  // publishers, diagnostic tasks, and related services
+  // will be initialized when corresponding meesage arrives
+  RCLCPP_INFO(get_logger(), "CABOT Touch Speed Node");
+
+  signal(SIGINT, TouchSpeedControlNode::signalHandler);
+
+  /* touch speed control
+  * touch speed activw mode
+  * True:  Touch - go,    Not Touch - no go
+  * False: Touch - no go, Not Touch - go
+  */
+  touch_speed_max_speed_ = this->declare_parameter("touch_speed_max_speed", touch_speed_max_speed_);
+  touch_speed_max_speed_inactive_ =
+    this->declare_parameter("touch_speed_max_speed_inactive", touch_speed_max_speed_inactive_);
+  rclcpp::QoS transient_local_qos(1);
+  transient_local_qos.transient_local();
+  touch_speed_switched_pub_ = this->create_publisher<std_msgs::msg::Float32>(
+    "touch_speed_switched", transient_local_qos);
+  set_touch_speed_active_mode_srv = this->create_service<std_srvs::srv::SetBool>(
+    "set_touch_speed_active_mode", std::bind(
+      &TouchSpeedControlNode::set_touch_speed_active_mode, this, std::placeholders::_1,
+      std::placeholders::_2));
+
+  touch_sub_ = this->create_subscription<std_msgs::msg::Int16>(
+    "touch", rclcpp::QoS(10), std::bind(&TouchSpeedControlNode::touch_callback, this, std::placeholders::_1));
+}
+
+
+// Private methods
+
+void TouchSpeedControlNode::signalHandler(int signal)
+{
+  (void)signal;  // avoid unused variable warning
+  exit(0);
+}
+
+void TouchSpeedControlNode::touch_callback(std_msgs::msg::Int16::SharedPtr msg)
+{
+  RCLCPP_INFO(get_logger(), "touch callback %d", msg->data);
+  std::unique_ptr<std_msgs::msg::Float32> touch_speed_msg =
+    std::make_unique<std_msgs::msg::Float32>();
+  if (touch_speed_active_mode_) {
+    touch_speed_msg->data = msg->data ? touch_speed_max_speed_ : 0.0;
+  } else {
+    touch_speed_msg->data = msg->data ? 0.0 : touch_speed_max_speed_inactive_;
+  }
+  touch_speed_switched_pub_->publish(std::move(touch_speed_msg));
+}
+
+void TouchSpeedControlNode::set_touch_speed_active_mode(
+  const std_srvs::srv::SetBool::Request::SharedPtr req,
+  std_srvs::srv::SetBool::Response::SharedPtr res)
+{
+  touch_speed_active_mode_ = req->data;
+  if (touch_speed_active_mode_) {
+    res->message = "touch speed active mode = True";
+  } else {
+    res->message = "touch speed active mode = False";
+  }
+  res->success = true;
+}
+
+}  // namespace CaBotSafety
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(CaBotSafety::TouchSpeedControlNode)


### PR DESCRIPTION
Separate touch speed control function from cabot_serial in cabot-driver and move them as a cabot safety control node.

## sub
- /cabot/touch

## pub
- /cabot/touch_speed_switched (topic)
- /cabot/set_touch_active_mode (service)

## related PR
- https://github.com/CMU-cabot/cabot-drivers/pull/28