### PR TITLE
Matsumura/add evaluation judgment to cabot site large room

### DIFF
--- a/cabot_navigation2/test/evaluator.py
+++ b/cabot_navigation2/test/evaluator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ###############################################################################
-# Copyright (c) 2024  IBM Corporation
+# Copyright (c) 2024  IBM Corporation and Miraikan
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cabot_navigation2/test/evaluator.py
+++ b/cabot_navigation2/test/evaluator.py
@@ -92,7 +92,6 @@ class Evaluator:
             self._evaluation_timer.cancel()
             self._evaluation_timer.destroy()
             self._evaluation_timer = None
-        self.reset()
 
     def get_evaluation_results(self):
         results = []

--- a/pedestrian_plugin/pedestrian/walk_straight.py
+++ b/pedestrian_plugin/pedestrian/walk_straight.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024  Carnegie Mellon University
+# Copyright (c) 2024  Carnegie Mellon University and Miraikan
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pedestrian_plugin/pedestrian/walk_straight.py
+++ b/pedestrian_plugin/pedestrian/walk_straight.py
@@ -20,13 +20,16 @@
 
 import ros
 import math
+import time
 from pedestrian import state
 
 stopped = False
+start_time = None
 
 
 def onUpdate(**args):
     global stopped
+    global start_time
 
     # parameters
     name = args['name']
@@ -37,6 +40,7 @@ def onUpdate(**args):
     stop_distance = args.get('stop_distance', 0.0)  # [m]
     radius = args.get('radius', 0.4)  # [m]
     args['radius'] = radius
+    stop_time = args.get('stop_time', 0.0)  # [s]
 
     # plugin variables
     x = args['x']
@@ -73,6 +77,13 @@ def onUpdate(**args):
         stopped = True
     if stopped:
         vel = 0.0
+
+    # wait for movement
+    if start_time is None:
+        start_time = time.time()
+    time_diff = time.time() - start_time
+    if time_diff < stop_time:
+        vel = 0
 
     # update actor variables
     args['x'] += vel * dt * math.cos(yaw)


### PR DESCRIPTION
[こちら](https://github.com/CMU-cabot/cabot_sites_test/pull/7)の変更とともに、cabot-navigationも機能追加や修正を行いました。
ご確認の程よろしくお願いいたします。

* metrics条件の追加関数を追加
* metrics条件に基づき、success/failを判定する関数を追加
* walk_straight.pyにsleepを追加（robotとactorの動きを揃えるため）