### PR TITLE
fix ros2/Dockerfile to record nmea and rtcm messages to a bag file

### DIFF
--- a/docker/ros2/Dockerfile
+++ b/docker/ros2/Dockerfile
@@ -88,7 +88,9 @@ RUN apt update && \
     ros-$ROS_DISTRO-joint-state-publisher \
     ros-$ROS_DISTRO-joint-state-publisher-gui \
     ros-$ROS_DISTRO-navigation2 \
+    ros-$ROS_DISTRO-nmea-msgs \
     ros-$ROS_DISTRO-rosidl-runtime-cpp \
+    ros-$ROS_DISTRO-rtcm-msgs \
 # pcl-ros is not ported yet
 # #    ros-$ROS_DISTRO-pcl-msgs \
 # #    ros-$ROS_DISTRO-pcl-ros \

--- a/docker/ros2/Dockerfile.debug
+++ b/docker/ros2/Dockerfile.debug
@@ -86,7 +86,9 @@ RUN apt update && \
     ros-$ROS_DISTRO-joint-state-publisher \
     ros-$ROS_DISTRO-joint-state-publisher-gui \
     ros-$ROS_DISTRO-navigation2 \
+    ros-$ROS_DISTRO-nmea-msgs \
     ros-$ROS_DISTRO-rosidl-runtime-cpp \
+    ros-$ROS_DISTRO-rtcm-msgs \
 # pcl-ros is not ported yet
 # #    ros-$ROS_DISTRO-pcl-msgs \
 # #    ros-$ROS_DISTRO-pcl-ros \


### PR DESCRIPTION
This pull request fixes a bug that launch.sh in [cabot](https://github.com/CMU-cabot/cabot) does not record NMEA and RTCM messages to a ROS 2 bag file.
Although NMEA and RTCM messages are published by nodes related to GNSS, installing those messages to ros2 docker image is necessary because bag service defined in [docker-compose-bag.yam](https://github.com/CMU-cabot/cabot/blob/7b6785a4e9310dd1ea2fa58e7e20051e677fdad6/docker-compose-bag.yaml)l is based on the ros2 docker image.