### PR TITLE
move dependencies from ros2_ws to ros2 docker build context

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -30,6 +30,16 @@ repositories:
     type: git
     url: https://github.com/CMU-cabot/tf2_web_republisher
     version: ros2
+  docker/ros2/rosbridge_suite:
+    type: git
+    url: https://github.com/CMU-cabot/rosbridge_suite
+    version: ros2-dev
+  # temporal fix until PR is merged and released
+  # https://github.com/ros/bond_core/pull/97
+  docker/ros2/bond_core:
+    type: git
+    url: https://github.com/CMU-cabot/bond_core.git
+    version: galactic-fix
 
   cabot-common:
     type: git
@@ -40,15 +50,3 @@ repositories:
     type: git
     url: https://github.com/CMU-cabot/cabot-description
     version: main
-
-  docker/home/ros2_ws/src/rosbridge_suite:
-    type: git
-    url: https://github.com/CMU-cabot/rosbridge_suite
-    version: ros2-dev
-
-  # temporal fix until PR is merged and released
-  # https://github.com/ros/bond_core/pull/97
-  docker/home/ros2_ws/src/bond_core:
-    type: git
-    url: https://github.com/CMU-cabot/bond_core.git
-    version: galactic-fix

--- a/docker/ros2/Dockerfile
+++ b/docker/ros2/Dockerfile
@@ -29,6 +29,8 @@ ENV UNDERLAY_WS=/opt/underlay_ws
 
 RUN mkdir -p $UNDERLAY_WS/src
 COPY ./tf2_web_republisher $UNDERLAY_WS/src/tf2_web_republisher
+COPY ./rosbridge_suite $UNDERLAY_WS/src/rosbridge_suite
+COPY ./bond_core $UNDERLAY_WS/src/bond_core
 
 WORKDIR $UNDERLAY_WS
 


### PR DESCRIPTION
- require to remove bond_cpp, rosbridge_suite from ./docker/home/ros2_ws/src
- redo ./setup-dependency.sh and build from image