### PR TITLE
fix gnss-based initial localization

### DIFF
--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -1418,9 +1418,9 @@ class MultiFloorManager:
         # disable gnss adjust in indoor invironments
         if self.indoor_outdoor_mode == IndoorOutdoorMode.INDOOR:
             # reset all gnss adjust
-            for floor in self.gnss_adjuster_dict.keys():
-                for area in self.gnss_adjuster_dict[floor].keys():
-                    self.gnss_adjuster_dict[floor][area].reset()
+            for _floor in self.gnss_adjuster_dict.keys():
+                for _area in self.gnss_adjuster_dict[_floor].keys():
+                    self.gnss_adjuster_dict[_floor][_area].reset()
 
         # use different covariance threshold for initial localization and tracking
         if (self.gnss_localization_time is None) and (self.mode is None):


### PR DESCRIPTION
fix a variable scope bug in multi_floor_manager that the variable `floor` used in for loop is referenced after the loop finished. (https://github.com/CMU-cabot/cabot-navigation/blob/ba44290161f7b2c3146026b4ae1c335563c604b8/mf_localization/script/multi_floor_manager.py#L1648)