### PR TITLE
fix costmap clearing in low_obstacle_layer

### DIFF
--- a/cabot_navigation2/launch/bringup_launch.py
+++ b/cabot_navigation2/launch/bringup_launch.py
@@ -343,7 +343,7 @@ def generate_launch_description():
                 'angle_increment': 0.00174,  # M_PI/180/10
                 'scan_time': 0.1,
                 'range_min': 0.05,
-                'range_max': 50.0,
+                'range_max': 5.0,  # must be greater than or equal to max_range parameters in low_obstacle_layer
                 'use_inf': True,
                 'inf_epsilon': 1.0,
                 # Concurrency level affects number of pointclouds queued for

--- a/cabot_navigation2/params/nav2_params.yaml
+++ b/cabot_navigation2/params/nav2_params.yaml
@@ -506,8 +506,8 @@ global_costmap:
           min_obstacle_height: -2.0
           max_obstacle_height: 2.0
           obstacle_min_range: 0.05
-          obstacle_max_range: 7.5
-          raytrace_max_range: 8.0
+          obstacle_max_range: 4.5
+          raytrace_max_range: 5.0
           clearing: True
           marking: True
           inf_is_valid: True # default: False

--- a/cabot_navigation2/params/nav2_params2.yaml
+++ b/cabot_navigation2/params/nav2_params2.yaml
@@ -276,8 +276,8 @@ global_costmap:
           min_obstacle_height: -2.0
           max_obstacle_height: 2.0
           obstacle_min_range: 0.05
-          obstacle_max_range: 7.5
-          raytrace_max_range: 8.0
+          obstacle_max_range: 4.5
+          raytrace_max_range: 5.0
           clearing: True
           marking: True
           inf_is_valid: True # default: False


### PR DESCRIPTION
This commit fixes a bug that costmap in the low obstacle layer is not correctly cleared by /livox_scan message.
This bug is caused by the fact that the z-coordinate of the inf points in /livox_scan message becomes out of range of ObstacleLayer when the robot is tilted. By reducing range_max parameter of livox_pointcloud_to_laserscan_node sufficiently small, this bug will no longer occur.