### PR TITLE
fix localization/Dockerfile to install pandas

### DIFF
--- a/docker/localization/Dockerfile
+++ b/docker/localization/Dockerfile
@@ -70,6 +70,7 @@ RUN apt update && \
     npm \
     python3-pip \
     python3-matplotlib \
+    python3-pandas \
     python3-sklearn \
     ros-${ROS_DISTRO}-diagnostic-updater \
     ros-${ROS_DISTRO}-gazebo-msgs \

--- a/docker/localization/Dockerfile.debug
+++ b/docker/localization/Dockerfile.debug
@@ -17,6 +17,7 @@ RUN apt update && \
     python-is-python3 \
     python3-pip \
     python3-matplotlib \
+    python3-pandas \
     python3-sklearn \
     ros-${ROS_DISTRO}-diagnostic-updater \
     ros-${ROS_DISTRO}-gazebo-msgs \


### PR DESCRIPTION
This commit fixes localization/Dockerfile to install pandas because a node used in mapping (trajectory_based_interpolator.py) imports pandas.

- https://github.com/CMU-cabot/cabot-navigation/blob/3e7e4da144252d941cddbae116d1589b59a1efe1/mf_localization/script/trajectory_based_interpolator.py#L28