### PR TITLE
make POI distance mode configurable

### DIFF
--- a/cabot_ui/cabot_ui/geojson.py
+++ b/cabot_ui/cabot_ui/geojson.py
@@ -750,6 +750,10 @@ class Facility(Object):
 class POI(Facility, geoutil.TargetPlace):
     """POI class"""
 
+    class DistanceMode(enum.IntEnum):
+        Point = 1
+        Line = 2
+
     @classmethod
     def marshal(cls, dic):
         """marshal POI object"""
@@ -761,7 +765,7 @@ class POI(Facility, geoutil.TargetPlace):
                     cls = DoorPOI
                 if category == '_nav_info_':
                     cls = InfoPOI
-                if category == '_cabot_speed_':
+                if category == '_cabot_speed_':  # default is _line_
                     cls = SpeedPOI
                 if category == '_nav_elevator_cab_':
                     cls = ElevatorCabPOI
@@ -782,10 +786,18 @@ class POI(Facility, geoutil.TargetPlace):
 
         super(POI, self).__init__(r=r, x=0, y=0, angle=angle, floor=self.floor, **dic)
 
-        self.sub_category = self.properties.hulop_sub_category \
-            if hasattr(self.properties, 'hulop_sub_category') else ""
-        self.minor_category = self.properties.hulop_minor_category \
-            if hasattr(self.properties, 'hulop_minor_category') else ""
+        self.sub_category = self.properties.hulop_sub_category or ""
+        self.minor_category = self.properties.hulop_minor_category or ""
+
+        # distance to the POI is calculated based on the mode
+        # Point mode: distance between a given pose and the POI location
+        # Line mode: the shortest distance between the given pose and the line perpendicular to the POI's heading
+        #
+        # Line mode is default for '_cabot_speed_' otherwise Point
+        # It can be overwritten by '_line_' or '_point_' in hulop_minor_category
+        self.distance_mode = POI.DistanceMode.Line if self.sub_category == "_cabot_speed_" else POI.DistanceMode.Point
+        self.distance_mode = POI.DistanceMode.Line if "_line_" in self.minor_category else self.distance_mode
+        self.distance_mode = POI.DistanceMode.Point if "_point_" in self.minor_category else self.distance_mode
 
         # backward compatibility
         self.local_pose = self
@@ -815,21 +827,23 @@ class POI(Facility, geoutil.TargetPlace):
     def reset(self):
         self.reset_target()
 
-    # distance is adjusted to by the TargetPoint orientation
+    # distance is adjusted to by the TargetPoint orientation if distance_mode is Line
     #                     <- T Target (orientation)
     #                        |
     #                        |
     # robot R ---distance--- o
     #
-    def distance_to(self, robot, adjusted=False):
+    def distance_to(self, robot):
         dist_TR = super(POI, self).distance_to(robot)
-        if not adjusted:
+        if self.distance_mode == POI.DistanceMode.Point:
             return dist_TR
-        pose_TR = geoutil.Pose.pose_from_points(self, robot)
-        yaw = geoutil.diff_angle(self.orientation, pose_TR.orientation)
-        adjusted = dist_TR * math.cos(yaw)
-        # CaBotRclpyUtil.debug(f"dist={dist_TR}, yaw={yaw}, adjusted={adjusted}")
-        return adjusted
+        if self.distance_mode == POI.DistanceMode.Line:
+            pose_TR = geoutil.Pose.pose_from_points(self, robot)
+            yaw = geoutil.diff_angle(self.orientation, pose_TR.orientation)
+            adjusted = dist_TR * math.cos(yaw)
+            # CaBotRclpyUtil.debug(f"dist={dist_TR}, yaw={yaw}, adjusted={adjusted}")
+            return adjusted
+        raise RuntimeError("Should not happen")
 
 
 class DoorPOI(POI):

--- a/cabot_ui/cabot_ui/geojson.py
+++ b/cabot_ui/cabot_ui/geojson.py
@@ -798,6 +798,7 @@ class POI(Facility, geoutil.TargetPlace):
         self.distance_mode = POI.DistanceMode.Line if self.sub_category == "_cabot_speed_" else POI.DistanceMode.Point
         self.distance_mode = POI.DistanceMode.Line if "_line_" in self.minor_category else self.distance_mode
         self.distance_mode = POI.DistanceMode.Point if "_point_" in self.minor_category else self.distance_mode
+        CaBotRclpyUtil.info(f"{self._id}, {self.sub_category=}, {self.distance_mode=}")
 
         # backward compatibility
         self.local_pose = self
@@ -884,8 +885,14 @@ class InfoPOI(POI):
 
     def __init__(self, **dic):
         super(InfoPOI, self).__init__(**dic)
-        if self.minor_category not in ["_priority_low_", "_priority_high_", "_priority_normal_", "_priority_required_", "", None]:
-            CaBotRclpyUtil.error(f"Invalid value for hulop_minor_category: {self.minor_category}")
+        temp = self.minor_category
+        for known_key in ["_priority_low_", "_priority_high_", "_priority_normal_", "_priority_required_", "_line_", "_point_"]:
+            if known_key in temp:
+                temp = temp.replace(known_key, "")
+        temp = temp.replace(" ", "")
+        temp = temp.replace(",", "")
+        if temp:
+            CaBotRclpyUtil.error(f"Invalid value for {self._id=} hulop_minor_category: ({temp}) {self.minor_category}")
 
     def get_minor_category(self):
         return self.minor_category

--- a/cabot_ui/cabot_ui/interface.py
+++ b/cabot_ui/cabot_ui/interface.py
@@ -303,11 +303,11 @@ class UserInterface(object):
             return SpeechPriority.LOW
         if isinstance(poi, cabot_ui.geojson.InfoPOI):
             nav_info_minor_category = poi.get_minor_category()
-            if nav_info_minor_category == "_priority_low_":
+            if "_priority_low_" in nav_info_minor_category:
                 return SpeechPriority.LOW
-            elif nav_info_minor_category == "_priority_high_":
+            elif "_priority_high_" in nav_info_minor_category:
                 return SpeechPriority.HIGH
-            elif nav_info_minor_category == "_priority_normal_":
+            elif "_priority_normal_" in nav_info_minor_category:
                 return SpeechPriority.NORMAL
             else:
                 return SpeechPriority.REQUIRED

--- a/cabot_ui/cabot_ui/navigation.py
+++ b/cabot_ui/cabot_ui/navigation.py
@@ -964,7 +964,7 @@ class Navigation(ControlBase, navgoal.GoalInterface):
         # check speed limit
         limit = self._max_speed
         for poi in self.speed_pois:
-            dist = poi.distance_to(current_pose, adjusted=True)  # distance adjusted by angle
+            dist = poi.distance_to(current_pose)
             if dist < 5.0:
                 if poi.in_angle(current_pose):  # and poi.in_angle(c2p):
                     limit = min(limit, max(poi.limit, max_v(max(0, dist-target_distance), expected_deceleration, expected_delay)))


### PR DESCRIPTION
- when you create a Nav POI (`_nav_poi_`)
  - you can add `_line_` or `_point`_ category in `hulop_minor_category` to configure mode for calculating distance between the robot and the POI
  - Default value
    - Speed POI (`_cabot_speed_`) -> default: `_line_`
    - Nav Info (`_nav_info_`) and others -> default: `_point_`
  - It works with speech priority settings for Nav Info
    - `_line_, _priority_low_`
