### PR TITLE
configurable CABOT_SITE_PKG_DIR, update related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
   HOST_UID             # host user UID (default=1000)
   HOST_GID             # host user GID (default=1000)
   HOST_TZ              # host timezone (default=UTC)
+  CABOT_SITE_PKG_DIR   # location of the cabot_site_pkg dir for map server
   ```
 - Options for image description (hold down right button for 1-3 seconds)
   ```

--- a/dependency-override.repos
+++ b/dependency-override.repos
@@ -5,7 +5,3 @@
 # 
 
 repositories:
-  cabot-common:
-    type: git
-    url: https://github.com/CMU-cabot/cabot-common
-    version: daisukes/separate-common-and-base

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -467,8 +467,6 @@ services:
           - linux/arm64
         output:
           - type=registry
-    env_file:
-      - ${ENV_FILE:-.empty-env}
     environment:
       - MONGO_HOST=mongodb://mongodb_lt:27017/navi_db
     depends_on:

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -395,7 +395,8 @@ services:
         output:
           - type=registry
     env_file:
-      - ${CABOT_MAP_SERVER_ENV_FILE:-${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}/$CABOT_SITE/share/$CABOT_SITE/server_data/server.env}
+      - path: ${CABOT_MAP_SERVER_ENV_FILE:-${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}/$CABOT_SITE/share/$CABOT_SITE/server_data/server.env}
+        required: false
     environment:
       - HOST_UID
       - HOST_GID

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -231,7 +231,7 @@ services:
     volumes:
 # code
       - type: bind
-        source: ./cabot_site_pkg/${CABOT_SITE}
+        source: ${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}/${CABOT_SITE}
         target: /home/developer/ros2_ws/install/${CABOT_SITE}
         bind:
           create_host_path: false
@@ -329,7 +329,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /tmp/.docker.xauth:/tmp/.docker.xauth
       - type: bind
-        source: ./cabot_site_pkg/${CABOT_SITE}
+        source: ${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}/${CABOT_SITE}
         target: /home/developer/loc_ws/install/${CABOT_SITE}
         bind:
           create_host_path: false
@@ -395,18 +395,21 @@ services:
         output:
           - type=registry
     env_file:
-      - ${ENV_FILE:-.empty-env}
+      - ${CABOT_MAP_SERVER_ENV_FILE:-${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}/$CABOT_SITE/share/$CABOT_SITE/server_data/server.env}
     environment:
+      - HOST_UID
+      - HOST_GID
       - HOST_TZ
+      - CABOT_SITE
       - 'HULOP_MAP_SERVICE=localhost:8080/map'
       - 'HULOP_MAP_SERVICE_USE_HTTP=true'
-      - 'HULOP_VCAP_SERVICES={"mongodb": [{"credentials": {"url": "mongodb://mongodb:27017/navi_db"}}]}'  # for local mongodb service
+      - 'HULOP_VCAP_SERVICES={"mongodb": [{"credentials": {"url": "mongodb://mongodb_ms:27017/navi_db"}}]}'  # for local mongodb service
       - 'EDITOR_API_KEY=local-server-editor-api-key'
       - 'SEARCH_BY_FLOOR_ENABLED=true'
       - 'SEARCH_BY_CATEGORY_ENABLED=true'
-#    depends_on:
-#      mongodb:
-#        condition: service_healthy
+    depends_on:
+      mongodb_ms:
+        condition: service_healthy
     ports:
       - 0.0.0.0:${MAP_SERVER_PORT:-9090}:8080
     networks:
@@ -419,22 +422,19 @@ services:
 
   map_data:
     extends: map_server
-    env_file:
-      - ${ENV_FILE:-.empty-env}
+    env_file: !override []
     ports: !override []  # this does not work if extended
     depends_on:
       map_server:
         condition: service_healthy
     command:
-      - "bash"
-      - "-c"
-      - "cp -r /server_data /home/runner_user/server_data && /home/runner_user/server-init.sh && /home/runner_user/server-data.sh -i /home/runner_user/server_data/MapData.geojson"
+      - /home/runner_user/server-init.sh
     volumes:
-      - ${CABOT_SERVER_DATA_MOUNT:-./doc}:/server_data
+      - ${CABOT_SITE_PKG_DIR:-./cabot_site_pkg}:/cabot_site_pkg
     networks:
       - mongodb_network
 
-  mongodb:
+  mongodb_ms:
 #    image : mongo:3.4.3  # there is no aarch64 image for this version
     image : mongo:4.4.25  # the latest v4 version as of Nov. 2023, works without server side modification
     environment:
@@ -445,7 +445,7 @@ services:
     networks:
       - mongodb_network
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo mongodb:27017/test --quiet
+      test: echo 'db.runCommand("ping").ok' | mongo mongodb_ms:27017/test --quiet
       interval: 3s
       timeout: 3s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,10 +122,10 @@ services:
     profiles:
       - map
 
-  mongodb:
+  mongodb_ms:
     extends:
       file: docker-compose-common.yaml
-      service: mongodb
+      service: mongodb_ms
     profiles:
       - map
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -21,8 +21,8 @@
 FROM ubuntu:jammy AS base
 
 ARG TZ="Etc/UTC"
-ARG UID=1001
-ARG GID=1001
+ARG UID=1000
+ARG GID=1000
 
 ENV TZ=$TZ \
         DEBIAN_FRONTEND="noninteractive"

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -1,25 +1,24 @@
 #!/bin/bash
+set -e
 
-S_UID=${S_UID:-1001}
-S_GID=${S_GID:-1001}
-HOST_TZ=${HOST_TZ:-UTC}
+# Default values
+HOST_UID=${HOST_UID:-1000}
+HOST_GID=${HOST_GID:-1000}
+HOST_TZ=${HOST_TZ:-Etc/UTC}
 
 if [[ $TZ != $HOST_TZ ]]; then
     # Setting up timezone
     ln -snf /usr/share/zoneinfo/$HOST_TZ /etc/localtime
-    echo $HOST_TZ | tee /etc/timezone
+    echo $HOST_TZ | sudo tee /etc/timezone
     export TZ=$HOST_TZ
 fi
 
 CONT_UID=$(id -u runner_user)
 CONT_GID=$(id -g runner_user)
-
-if [[ $CONT_UID -ne $S_UID ]] || [[ $CONT_GID -ne $S_GID ]]; then
-    echo "Updating $USERNAME with UID:$S_UID and GID:$S_GID"
-    # Update user and group ID to match S
-    groupmod -g $S_GID runner_user
-    usermod -u $S_UID -g $S_GID runner_user
-    chown -R "$S_UID:$S_GID" /home/runner_user
+if [[ $CONT_UID -ne $HOST_UID ]] || [[ $CONT_GID -ne $HOST_GID ]]; then
+    # Update user and group ID to match host
+    usermod -u $HOST_UID runner_user
+    groupmod -g $HOST_GID runner_user
 fi
 
 exec gosu runner_user "$@"


### PR DESCRIPTION
- needs to build image to test `./bake-docker.sh -i map_server`
- `CABOT_SITE_PKG_DIR` will override pkg dir only for the prod profile
- `-d` (development) mode will always use `cabot-navigation/cabot_sites`
- `mongodb` service is renamed to `mongodb_ms`
- fix MapData.geojson backup (will save the data to cabot_site_pkg/.tmp, cabot_sites/.tmp)