### PR TITLE
fix localization/Dockerfile to install pandas in the final image

### DIFF
--- a/docker/localization/Dockerfile
+++ b/docker/localization/Dockerfile
@@ -70,7 +70,6 @@ RUN apt update && \
     npm \
     python3-pip \
     python3-matplotlib \
-    python3-pandas \
     python3-sklearn \
     ros-${ROS_DISTRO}-diagnostic-updater \
     ros-${ROS_DISTRO}-gazebo-msgs \
@@ -202,6 +201,7 @@ RUN apt update && \
     npm \
     python3-pip \
     python3-matplotlib \
+    python3-pandas \
     python3-sklearn \
     ros-${ROS_DISTRO}-diagnostic-updater \
     ros-${ROS_DISTRO}-gazebo-msgs \


### PR DESCRIPTION
This commit fixes a bug that pandas cannot be used in localization docker image because pandas is installed only in a docker image used for building binaries but not in a final image.