### PR TITLE
install sudo command in map server docker image to fix error in entrypoint.sh

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -35,6 +35,7 @@ RUN apt update && \
         gosu \
         jq \
         openjdk-11-jre \
+        sudo \
         zip \
         && \
         apt clean && \


### PR DESCRIPTION
This pull request fixed the error in map_server [entrypoint.sh](https://github.com/CMU-cabot/cabot-navigation/blob/b589128957837fb36d8f34ee72396f9bc2014123/docker/server/entrypoint.sh#L12) that "sudo" command is not found when HOST_TZ variable is set.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>