### PR TITLE
Matsumura/debug for lidar speed control

### DIFF
--- a/cabot/config/cabot-control.yaml
+++ b/cabot/config/cabot-control.yaml
@@ -50,10 +50,6 @@ cabot:
       min_distance: 1.0
       limit_factor: 1.0
       min_distance: 1.0
-      front_region_width:
-        normal: 0.50
-        smallest: 0.25
-        small: 0.30
 
   people_speed_control_node: # old name cabot_e_people_speed:
     ros__parameters:

--- a/cabot/config/cabot-control.yaml
+++ b/cabot/config/cabot-control.yaml
@@ -49,7 +49,7 @@ cabot:
       min_speed: 0.0
       min_distance: 1.0
       limit_factor: 1.0
-      front_region_offset_x: 0.348 # Distance from the base_footprint to the front of the ACE robot
+      min_distance: 1.0
       front_region_width:
         normal: 0.50
         smallest: 0.25

--- a/cabot/config/cabot-control.yaml
+++ b/cabot/config/cabot-control.yaml
@@ -49,7 +49,11 @@ cabot:
       min_speed: 0.0
       min_distance: 1.0
       limit_factor: 1.0
-      front_angle_in_degree: 28.95  # 1.0 * sin(x/2) * 2 = 0.8
+      front_region_offset_x: 0.348 # Distance from the base_footprint to the front of the ACE robot
+      front_region_width:
+        normal: 0.50
+        smallest: 0.25
+        small: 0.30
 
   people_speed_control_node: # old name cabot_e_people_speed:
     ros__parameters:

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -246,6 +246,10 @@ private:
           continue;
         }
 
+        if ((min_range - min_distance_) / limit_factor_ < max_speed_) {
+          CaBotSafety::add_point(get_clock()->now(), curr, 0.2, 1, 1, 0, 1);
+        }
+
         if (line.length() < min_range) {
           min_range = line.length();
         }

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -40,12 +40,6 @@
 
 namespace CaBotSafety
 {
-enum class FootprintMode : int {
-  NORMAL = 0,
-  SMALLEST = 1,
-  SMALL = 3
-};
-
 class LiDARSpeedControlNode : public rclcpp::Node
 {
 public:

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -246,7 +246,7 @@ private:
           continue;
         }
 
-        if ((min_range - min_distance_) / limit_factor_ < max_speed_) {
+        if ((line.length() - min_distance_) / limit_factor_ < max_speed_) {
           CaBotSafety::add_point(get_clock()->now(), curr, 0.2, 1, 1, 0, 1);
         }
 

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -231,8 +231,8 @@ private:
       const double rect_height = max_speed_ * limit_factor_;
       Point region_ur_point(min_distance_ + rect_height, front_region_width_ / 2.0);
       Point region_ul_point(min_distance_ + rect_height, -front_region_width_ / 2.0);
-      Point region_lr_point(min_distance_, front_region_width_ / 2.0);
-      Point region_ll_point(min_distance_, -front_region_width_ / 2.0);
+      Point region_lr_point(0.0, front_region_width_ / 2.0);
+      Point region_ll_point(0.0, -front_region_width_ / 2.0);
 
       region_ur_point.transform(map_to_robot_tf2);
       region_ul_point.transform(map_to_robot_tf2);
@@ -262,9 +262,9 @@ private:
         point_in_map_frame.transform(map_to_robot_tf2 * robot_to_lidar_tf2);
 
         // Check if the point is in the front region
-        if (point_in_robot_frame.x > min_distance_ && fabs(point_in_robot_frame.y) < front_region_width_ / 2.0) {
+        if (point_in_robot_frame.x > 0.0 && fabs(point_in_robot_frame.y) < front_region_width_ / 2.0) {
           double local_speed_limit = (point_in_robot_frame.x - min_distance_) / limit_factor_;
-          if (min_speed_ < local_speed_limit && local_speed_limit < max_speed_) {
+          if (local_speed_limit < max_speed_) {
             CaBotSafety::add_point(get_clock()->now(), point_in_map_frame, 0.2, 1, 1, 0, 1);
           }
 

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022  Carnegie Mellon University
+// Copyright (c) 2020, 2024  Carnegie Mellon University and Miraikan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/cabot/src/safety/lidar_speed_control_node.cpp
+++ b/cabot/src/safety/lidar_speed_control_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2024  Carnegie Mellon University and Miraikan
+// Copyright (c) 2020, 2025  Carnegie Mellon University and Miraikan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- `front_check`処理を扇形領域から長方形領域に変更（ロボット付近で`front_check`の死角ができないようにするため。）
- デバッグのために、速度制限されるスキャンポイントについて、描画するように実装