### PR TITLE
change the diagnostic level of no fix status in ublox node from ERROR to WARN

### DIFF
--- a/mf_localization/configuration_files/ublox/zed_f9p_rover.yaml
+++ b/mf_localization/configuration_files/ublox/zed_f9p_rover.yaml
@@ -13,11 +13,14 @@ ublox:
 
     rate: 10.0 # Hz
 
-    # diagnostics
+    ## diagnostics
     ignore_fix_timestamp: true
     # fix_frequency_tolerance: 0.15
     # fix_frequency_window: 10
     # timestamp_status_min: 0
+    ## diagnostics (error level)
+    # fix_not_ok_error_level: 1  # WARN
+    no_fix_error_level: 1  # ERROR -> WARN
 
     # message publishers
     publish:


### PR DESCRIPTION
This pull request changes the diagnostic level of ublox NO FIX status from ERROR to WARN.
Because cabot is used in both indoor and outdoor environments, it is better not to treat NO FIX status as an ERROR.

To make effective this update, it is necessary to build ublox_gps package including commit https://github.com/CMU-cabot/ublox/commit/c4da26964213b0cddb05e408762c42c1dcb94769

