### PR TITLE
add CABOT_SITE_TAGS variable to allow selecting which maps to load

### DIFF
--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -101,6 +101,7 @@ publish_current_rate=0
 
 : ${CABOT_GAZEBO:=0}
 : ${CABOT_SITE:=}
+: ${CABOT_SITE_TAGS:='\"\"'}
 : ${CABOT_MODEL:=}
 : ${CABOT_SHOW_LOC_RVIZ:=0}
 : ${CABOT_HEADLESS:=0}
@@ -480,6 +481,7 @@ if [ $navigation -eq 0 ]; then
     com="$command ros2 launch mf_localization $launch_file \
                     robot:=$robot \
                     map_config_file:=$map \
+                    tags:=$CABOT_SITE_TAGS \
                     with_odom_topic:=true \
                     beacons_topic:=$beacons_topic \
                     wifi_topic:=$wifi_topic \

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -132,6 +132,7 @@ services:
       - CABOT_USE_GNSS=${CABOT_USE_GNSS:-0}
       - CABOT_MODEL
       - CABOT_SITE
+      - CABOT_SITE_TAGS
       - CABOT_SHOW_LOC_RVIZ=${CABOT_SHOW_LOC_RVIZ:-1}
       - CABOT_HEADLESS
       # ROS2/DDS

--- a/mf_localization/launch/multi_floor_2d_rss_localization.launch.py
+++ b/mf_localization/launch/multi_floor_2d_rss_localization.launch.py
@@ -45,6 +45,7 @@ def generate_launch_description():
     rssi_offset = LaunchConfiguration('rssi_offset')
 
     map_config_file = LaunchConfiguration('map_config_file')
+    tags = LaunchConfiguration('tags')
     beacons_topic = LaunchConfiguration('beacons_topic')
     wifi_topic = LaunchConfiguration('wifi_topic')
     with_odom_topic = LaunchConfiguration('with_odom_topic')
@@ -74,6 +75,7 @@ def generate_launch_description():
         DeclareLaunchArgument('rssi_offset', default_value='0.0', description='Set RSSI offset to estimate location'),
 
         DeclareLaunchArgument('map_config_file', default_value='', description='Specify map config file path'),
+        DeclareLaunchArgument('tags', default_value='', description='Specify tags to select which maps to load (comma-separated string e.g. v0.2,demo)'),
         DeclareLaunchArgument('beacons_topic', default_value='beacons', description='Specify beacons topic name'),
         DeclareLaunchArgument('wifi_topic', default_value='wifi', description='Specify wifi topic name'),
         DeclareLaunchArgument('with_odom_topic', default_value='false', description='Weather odom topic is used to cartographer localization or not'),
@@ -123,6 +125,7 @@ def generate_launch_description():
                 name='multi_floor_manager',
                 parameters=[{
                     'map_config_file': map_config_file,
+                    'tags': tags,
                     'configuration_directory': pkg_dir+'/configuration_files/cartographer',
                     'configuration_file_prefix': 'cartographer_2d',
                     'robot': robot,

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -393,6 +393,8 @@ class TagUtil:
                     if ver_tag in spec_tag:
                         match = True
                 else:
+                    if spec_tag == "all":  # special string
+                        match = True
                     if ver_tag == spec_tag:
                         match = True
         return match
@@ -2548,7 +2550,7 @@ if __name__ == "__main__":
         frame_id = map_dict["frame_id"]
 
         # parse specifier tags and compare with version tags
-        map_tags_input = map_dict.get("tags", ">=0")
+        map_tags_input = map_dict.get("tags", "all")
         map_tags = TagUtil.parse_specifier_tags_input(map_tags_input)
         skip = not TagUtil.versions_in_specifiers(tags, map_tags)
         map_dict["skip"] = skip

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -347,8 +347,14 @@ class RSSLocalizationParameters:
 
 class TagUtil:
     @staticmethod
-    def parse_version_tag_string(tags_string):
-        tags = tags_string.split(",")
+    def parse_version_tags_input(tags_input: list | str):
+        tags = []
+        if type(tags_input) is list:
+            for tag in tags_input:
+                tags_temp = [t.strip() for t in tag.split(",")]
+                tags.extend(tags_temp)
+        else:  # comma-separated str
+            tags = [t.strip() for t in tags_input.split(",")]
         tags2 = []
         for tag in tags:
             try:
@@ -359,8 +365,14 @@ class TagUtil:
         return tags
 
     @staticmethod
-    def parse_specifier_tag_string(tags_string):
-        tags = tags_string.split(",")
+    def parse_specifier_tags_input(tags_input: list | str):
+        tags = []
+        if type(tags_input) is list:
+            for tag in tags_input:
+                tags_temp = [t.strip() for t in tag.split(",")]
+                tags.extend(tags_temp)
+        else:  # comma-separated str
+            tags = [t.strip() for t in tags_input.split(",")]
         tags2 = []
         for tag in tags:
             try:
@@ -2327,7 +2339,7 @@ if __name__ == "__main__":
     else:
         map_config["tags"] = launch_tags
     # parse version tags
-    tags = TagUtil.parse_version_tag_string(launch_tags)
+    tags = TagUtil.parse_version_tags_input(launch_tags)
     logger.info(f"launch tags = {tags}")
 
     sub_topics = node.declare_parameter("topic_list", ['beacons', 'wireless/beacons', 'wireless/wifi']).value
@@ -2536,8 +2548,8 @@ if __name__ == "__main__":
         frame_id = map_dict["frame_id"]
 
         # parse specifier tags and compare with version tags
-        map_tags_str = map_dict.get("tags", ">=0")
-        map_tags = TagUtil.parse_specifier_tag_string(map_tags_str)
+        map_tags_input = map_dict.get("tags", ">=0")
+        map_tags = TagUtil.parse_specifier_tags_input(map_tags_input)
         skip = not TagUtil.versions_in_specifiers(tags, map_tags)
         map_dict["skip"] = skip
 

--- a/mf_localization_mapping/launch/demo_multi_2d_VLP16_rss_localization.launch.py
+++ b/mf_localization_mapping/launch/demo_multi_2d_VLP16_rss_localization.launch.py
@@ -57,6 +57,7 @@ def generate_launch_description():
 
     # multi-floor manager
     map_config_file = LaunchConfiguration('map_config_file')
+    tags = LaunchConfiguration('tags')
     beacon_topic = LaunchConfiguration('beacon_topic')
     wifi_topic = LaunchConfiguration('wifi_topic')
     rssi_offset = LaunchConfiguration('rssi_offset')
@@ -165,6 +166,7 @@ def generate_launch_description():
 
         # multi-floor manager
         DeclareLaunchArgument('map_config_file'),
+        DeclareLaunchArgument('tags', default_value=''),
         DeclareLaunchArgument('beacon_topic', default_value='beacons'),
         DeclareLaunchArgument('wifi_topic', default_value='wifi'),
         DeclareLaunchArgument('rssi_offset', default_value=''),
@@ -301,6 +303,7 @@ def generate_launch_description():
                     {
                         'use_sim_time': use_sim_time,
                         'map_config_file': map_config_file,
+                        'tags': tags,
                         'configuration_directory': PathJoinSubstitution([mf_localization_dir, 'configuration_files', 'cartographer']),
                         'configuration_file_prefix': 'cartographer_2d',
                         'pressure_available': pressure_available,


### PR DESCRIPTION
This pull request adds CABOT_SITE_TAGS variable to allow setting which maps to load for localization without modifying data in cabot_site package.
When CABOT_SITE_TAGS is not specified and `tags` variables are not defined in the cabot_site map yaml file, all maps are loaded.

- Example
  - cabot_site yaml config
    ```
        tags: "v0.2"  # default tags
        map_list:
          - # east map
            node_id: "carto0_0"
            tags: ">=0.1,east,A"
            ...
          - # north map
            node_id: "carto0_1"
            tags: ">=0.2,north,A"
            ...
          - # west map
            node_id: "carto0_2"
            tags: ">=0.3,west,B"
            ...
          - # south map
            node_id: "carto0_3"
            tags: ">=0.4,south,B"
            ...
    ```
  - CABOT_SITE_TAGS setting examples
    - `CABOT_SITE_TAGS=v0.2` -> selects `east map` and `north map`
    - `CABOT_SITE_TAGS=v0.2,south` -> selects  `east map`, `north map` and `south map`
    - `CABOT_SITE_TAGS=north,south` -> selects  `north map` and `south map`
    - `CABOT_SITE_TAGS=A` -> selects  `west map` and `south map`
    - `CABOT_SITE_TAGS=all` -> selects  all maps (reserved keyword)