### PR TITLE
add a service to reset GNSS to multi floor manager

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -20,7 +20,7 @@ repositories:
     # added topic name fix
     type: git
     url: https://github.com/CMU-cabot/ublox.git
-    version: ros2-fix-topic-name
+    version: ros2-cabot
   docker/localization/ntrip_client:
     type: git
     url: https://github.com/cmu-cabot/ntrip_client.git


### PR DESCRIPTION
This commit adds a service to reset GNSS by calling a low-level service in ublox node.

Usage
```
$ ros2 service call /reset_gnss mf_localization_msgs/srv/MFTrigger
```