### PR TITLE
fix local low obstacle layer parameters

### DIFF
--- a/cabot_navigation2/params/nav2_params.yaml
+++ b/cabot_navigation2/params/nav2_params.yaml
@@ -427,7 +427,7 @@ local_costmap:
         max_obstacle_height: 2.0
         observation_sources: scan
         scan:
-          topic: /livox_scan_expand
+          topic: /livox_scan # use original scan to prevent clearing the cost during obstacle avoidance
           min_obstacle_height: -2.0
           max_obstacle_height: 2.0
           obstacle_min_range: 0.05
@@ -507,7 +507,7 @@ global_costmap:
         max_obstacle_height: 2.0
         observation_sources: scan
         scan:
-          topic: /livox_scan_expand
+          topic: /livox_scan_expand # use expanded scan to clear noise at the edge of the field of view
           min_obstacle_height: -2.0
           max_obstacle_height: 2.0
           obstacle_min_range: 0.05


### PR DESCRIPTION
fix local low obstacle layer parameters in following points
- use ObstacleLayer instead of TemporalObstacleLayer to prevent moving close to obstacles
- use /livox_scan topic instead of livox_scan_expand topic to prevent clearing the cost during obstacle avoidance