### PR TITLE
add localization constraints monitor to estimate the reliability of location tracking

### DIFF
--- a/cabot_ui/config/cabot3-k1_diagnostic.yaml
+++ b/cabot_ui/config/cabot3-k1_diagnostic.yaml
@@ -29,7 +29,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
-        - "Scan Matching Status"
+        - "Localization Health Monitor"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/cabot_ui/config/cabot3-k1_diagnostic.yaml
+++ b/cabot_ui/config/cabot3-k1_diagnostic.yaml
@@ -29,6 +29,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
+        - "Scan Matching Status"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/cabot_ui/config/cabot3-k4_diagnostic.yaml
+++ b/cabot_ui/config/cabot3-k4_diagnostic.yaml
@@ -29,7 +29,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
-        - "Scan Matching Status"
+        - "Localization Health Monitor"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/cabot_ui/config/cabot3-k4_diagnostic.yaml
+++ b/cabot_ui/config/cabot3-k4_diagnostic.yaml
@@ -29,6 +29,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
+        - "Scan Matching Status"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/cabot_ui/config/cabot_diagnostic.yaml
+++ b/cabot_ui/config/cabot_diagnostic.yaml
@@ -28,7 +28,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
-        - "Scan Matching Status"
+        - "Localization Health Monitor"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/cabot_ui/config/cabot_diagnostic.yaml
+++ b/cabot_ui/config/cabot_diagnostic.yaml
@@ -28,6 +28,7 @@ diagnostic_aggregator:
       path: "Soft: Localize"
       contains:
         - "Localize Status"
+        - "Scan Matching Status"
       remove_prefix:
         - "multi_floor_manager: "
 

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -627,7 +627,7 @@ class MultiFloorManager:
                 age = now - floor_manager.scan_match_last_update_time
                 stat.add("scan_match_last_update_sec", f"{age.nanoseconds / 1e9:.1f}")
             if floor_manager.scan_match_distance_since_update is not None:
-                stat.add("scan_match_last_update_distance", f"{floor_manager.scan_match_distance_since_update:.1f}")
+                stat.add("scan_match_last_update_distance", f"{floor_manager.scan_match_distance_since_update:.2f}")
             stat.add("scan_match_no_update_detected", str(floor_manager.scan_match_no_update_detected))
             # fix constraint
             stat.add("fix_constraints_count", str(floor_manager.fix_constraints_count))
@@ -635,7 +635,7 @@ class MultiFloorManager:
                 age = now - floor_manager.fix_last_update_time
                 stat.add("fix_last_update_sec", f"{age.nanoseconds / 1e9:.1f}")
             if floor_manager.fix_distance_since_update is not None:
-                stat.add("fix_last_update_distance", f"{floor_manager.fix_distance_since_update:.1f}")
+                stat.add("fix_last_update_distance", f"{floor_manager.fix_distance_since_update:.2f}")
             stat.add("fix_no_update_detected", str(floor_manager.fix_no_update_detected))
             if floor_manager.scan_match_no_update_detected:
                 if floor_manager.fix_no_update_detected:

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -433,10 +433,10 @@ class MultiFloorManagerParameters:
     scan_match_distance_min_step: float = 0.05  # [m]
     scan_match_monitor_interval: float = 2.5  # [s]
     scan_match_min_increment: int = 1
-    scan_match_no_update_timeout: float = 300.0  # [s]
-    scan_match_no_update_distance: float = 5.0  # [m]
-    fix_no_update_timeout: float = 600.0  # [s]
-    fix_no_update_distance: float = 5.0  # [m]
+    scan_match_no_update_timeout: float = 300.0  # [s], <= 0 disables
+    scan_match_no_update_distance: float = 5.0  # [m], <= 0 disables
+    fix_no_update_timeout: float = 0.0  # [s], <= 0 disables
+    fix_no_update_distance: float = 5.0  # [m], <= 0 disables
     enable_unreliable_status: bool = False  # disable unreliable status by default
 
 
@@ -1497,8 +1497,10 @@ class MultiFloorManager:
         distance = floor_manager.scan_match_distance_since_update
         # flag as stale only if time or distance thresholds are exceeded
         if not floor_manager.scan_match_no_update_detected:
-            if elapsed > Duration(seconds=self.params.scan_match_no_update_timeout) \
-                    or distance >= self.params.scan_match_no_update_distance:
+            if (self.params.scan_match_no_update_timeout > 0
+                and elapsed > Duration(seconds=self.params.scan_match_no_update_timeout)) \
+                    or (self.params.scan_match_no_update_distance > 0
+                        and distance >= self.params.scan_match_no_update_distance):
                 floor_manager.scan_match_no_update_detected = True
         self.scan_match_no_update_pub.publish(Bool(data=floor_manager.scan_match_no_update_detected))
 
@@ -1506,8 +1508,10 @@ class MultiFloorManager:
         fix_distance = floor_manager.fix_distance_since_update
         if floor_manager.fix_last_update_time is not None and not floor_manager.fix_no_update_detected:
             fix_elapsed = now - floor_manager.fix_last_update_time
-            if fix_elapsed > Duration(seconds=self.params.fix_no_update_timeout) \
-                    or fix_distance >= self.params.fix_no_update_distance:
+            if (self.params.fix_no_update_timeout > 0
+                and fix_elapsed > Duration(seconds=self.params.fix_no_update_timeout)) \
+                    or (self.params.fix_no_update_distance > 0
+                        and fix_distance >= self.params.fix_no_update_distance):
                 floor_manager.fix_no_update_detected = True
         self.fix_no_update_pub.publish(Bool(data=floor_manager.fix_no_update_detected))
 

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -625,7 +625,7 @@ class MultiFloorManager:
                 stat.add("last_update_sec", f"{age.nanoseconds / 1e9:.1f}")
             if floor_manager.scan_match_distance_since_update is not None:
                 stat.add("last_update_distance", f"{floor_manager.scan_match_distance_since_update:.1f}")
-            stat.add("scan_match_no_update_detected", str(floor_manager.fix_no_update_detected))
+            stat.add("scan_match_no_update_detected", str(floor_manager.scan_match_no_update_detected))
             # fix constraint
             stat.add("fix_constraints_count", str(floor_manager.fix_constraints_count))
             if floor_manager.fix_last_update_time is not None:

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -610,7 +610,7 @@ class MultiFloorManager:
             return stat
         self.updater.add(FunctionDiagnosticTask("Localize Status", localize_status))
 
-        def scan_match_status(stat):
+        def localization_health_monitor(stat):
             now = self.clock.now()
             floor_manager = self.get_active_floor_manager()
             if floor_manager is None \
@@ -622,9 +622,9 @@ class MultiFloorManager:
             stat.add("pose_graph_constraints_count", str(floor_manager.pose_graph_constraints_count))
             if floor_manager.scan_match_last_update_time is not None:
                 age = now - floor_manager.scan_match_last_update_time
-                stat.add("last_update_sec", f"{age.nanoseconds / 1e9:.1f}")
+                stat.add("scan_match_last_update_sec", f"{age.nanoseconds / 1e9:.1f}")
             if floor_manager.scan_match_distance_since_update is not None:
-                stat.add("last_update_distance", f"{floor_manager.scan_match_distance_since_update:.1f}")
+                stat.add("scan_match_last_update_distance", f"{floor_manager.scan_match_distance_since_update:.1f}")
             stat.add("scan_match_no_update_detected", str(floor_manager.scan_match_no_update_detected))
             # fix constraint
             stat.add("fix_constraints_count", str(floor_manager.fix_constraints_count))
@@ -642,7 +642,7 @@ class MultiFloorManager:
             else:
                 stat.summary(DiagnosticStatus.OK, "OK")
             return stat
-        self.updater.add(FunctionDiagnosticTask("Scan Matching Status", scan_match_status))
+        self.updater.add(FunctionDiagnosticTask("Localization Health Monitor", localization_health_monitor))
 
     # state getter/setter
     @property

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -247,7 +247,6 @@ class FloorManager:
         # variables (scan matching monitoring)
         self.constraint_builder_constraints_count = None
         self.scan_match_last_update_time = None
-        self.scan_match_last_update_xy = None
         self.scan_match_no_update_detected = False
         self.scan_match_distance_since_update = 0.0
         self.scan_match_prev_xy = None
@@ -269,7 +268,6 @@ class FloorManager:
         # variables (scan matching monitoring)
         self.constraint_builder_constraints_count = None
         self.scan_match_last_update_time = None
-        self.scan_match_last_update_xy = None
         self.scan_match_no_update_detected = False
         self.scan_match_distance_since_update = 0.0
         self.scan_match_prev_xy = None
@@ -1455,7 +1453,6 @@ class MultiFloorManager:
             floor_manager.pose_graph_constraints_count = pose_graph_count
             floor_manager.last_pose_graph_update_time = now
             floor_manager.scan_match_last_update_time = now
-            floor_manager.scan_match_last_update_xy = current_xy
             floor_manager.scan_match_no_update_detected = False
             floor_manager.scan_match_distance_since_update = 0.0
             floor_manager.fix_last_update_time = now
@@ -1481,7 +1478,6 @@ class MultiFloorManager:
                 and floor_manager.last_pose_graph_update_time is not None \
                 and floor_manager.last_pose_graph_update_time >= floor_manager.pending_constraint_update_time:
             floor_manager.scan_match_last_update_time = floor_manager.last_pose_graph_update_time
-            floor_manager.scan_match_last_update_xy = current_xy
             floor_manager.scan_match_no_update_detected = False
             floor_manager.scan_match_distance_since_update = 0.0
             floor_manager.pending_constraint_update_time = None

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -436,10 +436,10 @@ class MultiFloorManagerParameters:
     localization_health_monitor_interval: float = 2.5  # [s]
     scan_match_min_increment: int = 1
     scan_match_no_update_timeout: float = 300.0  # [s], <= 0 disables
-    scan_match_no_update_distance: float = 5.0  # [m], <= 0 disables
+    scan_match_no_update_distance: float = 10.0  # [m], <= 0 disables
     fix_motion_filter_distance = 0.2  # [m]
     fix_no_update_timeout: float = 300.0  # [s], <= 0 disables
-    fix_no_update_distance: float = 5.0  # [m], <= 0 disables
+    fix_no_update_distance: float = 10.0  # [m], <= 0 disables
     enable_unreliable_status: bool = False  # disable unreliable status by default
 
 


### PR DESCRIPTION
This change enables localization health monitor that enables warnings when pose constraints for localization are not found.
Pose constraints include (1) scan matching constraints between a scan and each submap and (2) GNSS fix constraints.

The alerting behavior can be configured by setting the parameters in the yaml config file in cabot site. 
```
multi_floor_manager:
  # parameters for constraint monitor
  scan_match_no_update_timeout: 300.0  # default: 300.0 [s], <= 0 disables / Raise a warning when the scan matcher cannot find new constraints for longer than the timeout threshold 
  scan_match_no_update_distance: 10.0  # default: 10.0 [m], <= 0 disables / Raise a warning when the scan matcher cannot find new constraints after travelling more than the threshold distance
  fix_no_update_timeout: 300.0  # default: 300 [s], <= 0 disables / Raise a warning when accurate RTK GNSS fix costraints not found for longer than the timeout threshold
  fix_no_update_distance: 10.0  # default: 10.0[m], <= 0 disables / Raise a warning when accurate RTK GNSS fix constraints not found after travelling more than the threshold distance
  enable_unreliable_status: false  # default: false / Publish unrelable to /localize_status topic
```