### PR TITLE
Fix pause/resume race by ignoring stale Nav2 goal handles/results

### DIFF
--- a/cabot_ui/cabot_ui/navgoal.py
+++ b/cabot_ui/cabot_ui/navgoal.py
@@ -450,7 +450,9 @@ class Goal(geoutil.TargetPlace):
         self._send_seq = 0
         self._active_send_seq = 0
         # Cancel applies to all sends up to this sequence number.
-        self._cancel_upto_send_seq = 0
+        # Use -1 so that goals which don't use _new_action_callbacks (e.g., TurnGoal/Spin)
+        # are not accidentally canceled when their first handle arrives with send_seq==0.
+        self._cancel_upto_send_seq = -1
 
     def reset(self):
         self._is_completed = False


### PR DESCRIPTION
背景
- マップ切り替えや一時停止→再開の直後に、ナビゲーションが再開しない／すぐ goal_canceled になることがある。
- 原因として、Nav2(NavigateToPose) の Action が非同期で動くため、
  1) pause 側のキャンセル処理
  2) resume 側の新しい goal 送信
  3) 古い goal の handle / result が「遅れて」返ってくる
  が同時期に混ざり、同じ Goal(NavGoal) オブジェクトの状態を古い情報で上書きしてしまう競合（レースコンディション）が起き得る。

変更の意図
- pause 前に送った古い Action の handle / result が、resume 後に送った新しい Action に影響しないようにする。
  （古い result が来ても、新しい送信に対する処理として扱わない）

変更内容（要点）
1) Action送信ごとのシーケンス番号を導入
- Goal に _send_seq / _active_send_seq / _cancel_upto_send_seq を追加。
- navigate_to_pose を呼ぶ直前に _new_action_callbacks(done_cb) を使って、
  「この送信専用」の goal_handle_callback / done_callback を生成。

2) 古い result を無視
- done_callback は send_seq を確認し、現在の active send と一致しない（=古い送信の result）場合は
  "Ignoring stale action result" として無視する。

3) cancel が新しい送信を巻き込まないようにする
- cancel は「cancel を要求した時点までの send_seq（_cancel_upto_send_seq）」に紐づく handle だけを対象にする。
- これにより、pause 中の cancel 継続処理が resume 後の新しい goal handle を巻き込んで cancel してしまう可能性を減らす。

対象箇所
- NavGoal / ElevatorInGoal / ElevatorOutGoal / QueueNavGoal の navigate_to_pose 呼び出しで
  _new_action_callbacks を使うように変更。