### PR TITLE
F miyazaki/fix UI stop reason event order

### DIFF
--- a/cabot_ui/cabot_ui/geojson.py
+++ b/cabot_ui/cabot_ui/geojson.py
@@ -1171,7 +1171,7 @@ class SignalPOI(POI):
             return None
 
         timestamp = SignalPOI.last_status[0]['timestamp'] if 'timestamp' in SignalPOI.last_status[0] else None
-        if timestamp is None or (time.time() - timestamp) > 1.0:
+        if timestamp is None or (time.time() - timestamp) > 3.0:
             SignalPOI.last_status = []
             return None
 

--- a/cabot_ui/scripts/cabot_ui_manager.py
+++ b/cabot_ui/scripts/cabot_ui_manager.py
@@ -76,7 +76,7 @@ class CabotUIManager(object):
             return self.speed_menu.value
         self._interface.user_speed = types.MethodType(user_speed, self)
 
-        plugins = os.environ.get('CABOT_UI_PLUGINS', "feature,speaker,description,navigation").split(",")
+        plugins = os.environ.get('CABOT_UI_PLUGINS', "feature,speaker,navigation,description").split(",")
         self._navigation_plugins = NavigationPlugins(plugins, node_manager, self._interface)
         # self._exploration = Exploration()
         # self._exploration.delegate = self


### PR DESCRIPTION
デフォルトではnavigationのpluginよりも先にdescriptionのpluginが呼び出されるため、右ボタンを押すとナビゲーション開始時に必ずstop_reasonが呼ばれるバグがありました。
なのでデフォルトの順番を入れ替えました。

また、
> この「信号情報がありません」メッセージの読み上げは必要でしょうか？1秒以内に情報が取れないとナビゲーションに支障があるのであれば一時停止すべきです。あるいはチェックの間隔を1秒ではなく3秒にするとか？ここの1.0を変更するのが一番安全そうですね。

の変更もついでに入れておいてとお願いされたのでcommitは分けましたが、PRは同じにしました。