### PR TITLE
Fix signal_state proximity gating and clear stale signal stop reasons

### DIFF
--- a/cabot_ui/cabot_ui/geojson.py
+++ b/cabot_ui/cabot_ui/geojson.py
@@ -907,6 +907,18 @@ class POI(Facility, geoutil.TargetPlace):
         # CaBotRclpyUtil.debug(f"dist={dist_TR}, yaw={yaw}, adjusted={adjusted}")
         return adjusted
 
+    # width is the cross-track distance to the POI orientation
+    #                       |
+    #                       | width (+/-)
+    # robot R --------------+--------------> (POI orientation)
+    #                       o POI
+    #
+    def width_to(self, robot):
+        dist_TR = super(POI, self).distance_to(robot)
+        pose_TR = geoutil.Pose.pose_from_points(self, robot)
+        yaw = geoutil.diff_angle(self.orientation, pose_TR.orientation)
+        return dist_TR * math.sin(yaw)
+
 
 class DoorPOI(POI):
     """POI class"""

--- a/cabot_ui/src/stop_reasoner.hpp
+++ b/cabot_ui/src/stop_reasoner.hpp
@@ -294,6 +294,8 @@ private:
   std::string last_log_;
   std::string current_frame_;
   std::string signal_state_;
+  rclcpp::Time last_signal_state_time_;
+  double signal_state_timeout_sec_;
   rclcpp::Time no_signal_info_start_;
   AverageFilter linear_velocity_;
   AverageFilter angular_velocity_;


### PR DESCRIPTION
- SignalPOI の適用判定は「進行方向の投影距離 dist が 5m 未満」かつ「横ずれ width が ±2m 以内」で行い、範囲外ならその POI は無視する
- NONE の publish は「ループ全体で該当する信号POIが1つも無い」かつ「横断中(crossing)でもない」場合だけにする（近傍なのに信号が取れない NO_SIGNAL_INFO で NONE を出さない）
- stop_reasoner 側は /cabot/signal_state が一定秒数（例: 3秒）更新されていなければ、信号由来の停止理由（RED/GREEN_SHORT/NO_SIGNAL_INFO）に使わない（クリア扱いにする）