### PR TITLE
Revert "fix low_obstacle_layer, mark with PointCloud2 and clear with scan

### DIFF
--- a/cabot_navigation2/params/nav2_params.yaml
+++ b/cabot_navigation2/params/nav2_params.yaml
@@ -425,18 +425,7 @@ local_costmap:
         rising_rate: 25
         min_obstacle_height: -2.0
         max_obstacle_height: 2.0
-        observation_sources: "livox scan"   # marking with livox and clearing with scan
-        livox:
-          topic: /livox/points_filtered
-          min_obstacle_height: -2.0
-          max_obstacle_height: 2.0
-          obstacle_min_range: 0.05
-          obstacle_max_range: 4.0
-          raytrace_max_range: 5.0
-          clearing: False
-          marking: True
-          inf_is_valid: True # default: False
-          data_type: "PointCloud2"
+        observation_sources: scan
         scan:
           topic: /livox_scan # use original scan to prevent clearing the cost during obstacle avoidance
           min_obstacle_height: -2.0
@@ -445,7 +434,7 @@ local_costmap:
           obstacle_max_range: 4.0
           raytrace_max_range: 5.0
           clearing: True
-          marking: False
+          marking: True
           inf_is_valid: True # default: False
           data_type: "LaserScan"
       static_layer:
@@ -516,18 +505,7 @@ global_costmap:
         rising_rate: 25
         min_obstacle_height: -2.0
         max_obstacle_height: 2.0
-        observation_sources: "livox scan"   # marking with livox and clearing with scan
-        livox:
-          topic: /livox/points_filtered
-          min_obstacle_height: -2.0
-          max_obstacle_height: 2.0
-          obstacle_min_range: 0.05
-          obstacle_max_range: 4.5
-          raytrace_max_range: 5.0
-          clearing: False
-          marking: True
-          inf_is_valid: True # default: False
-          data_type: "PointCloud2"
+        observation_sources: scan
         scan:
           topic: /livox_scan_expand # use expanded scan to clear noise at the edge of the field of view
           min_obstacle_height: -2.0


### PR DESCRIPTION
This reverts commit 6ad69e32746c9780af19aa6fddfcf684f1ae8b31.
Marking with Livox point cloud and clearing with Livox scan may cause issue, actual Livox FOV may not match with spec exactly.