### PR TITLE
Filter nearby facility announcements by current floor

### DIFF
--- a/cabot_ui_plugins/cabot_ui_plugins/navigation/navigation.py
+++ b/cabot_ui_plugins/cabot_ui_plugins/navigation/navigation.py
@@ -1044,7 +1044,14 @@ class Navigation(ControlBase, navgoal.GoalInterface):
     def _check_nearby_facility(self, current_pose):
         if not self.nearby_facilities:
             return
-        entry = min(self.nearby_facilities, key=lambda p, c=current_pose: abs(p["entrance"].distance_to(c)))
+
+        entries = self.nearby_facilities
+        if self.current_floor is not None:
+            entries = [entry for entry in entries if entry["entrance"].same_floor(self.current_floor)]
+            if not entries:
+                return
+
+        entry = min(entries, key=lambda p, c=current_pose: abs(p["entrance"].distance_to(c)))
         if entry is None:
             return
         entrance = entry["entrance"]


### PR DESCRIPTION
階を跨いでナビゲーションする際にread POIを全て含むものの、読み上げ発火条件には2D上でしか見ていないため階を無視して読み上げられる問題の対応

- https://github.com/miraikan-research/TODO/issues/1404
