### PR TITLE
add record camera option in mapping mode

### DIFF
--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -119,6 +119,7 @@ if [[ $CABOT_HEADLESS -eq 1 ]]; then
 fi
 : ${CABOT_PRESSURE_AVAILABLE:=0}
 : ${CABOT_ROSBAG_COMPRESSION:='message'}
+: ${CABOT_ROSBAG_RECORD_CAMERA:=0}
 : ${CABOT_USE_GNSS:=0}
 # global localizer
 : ${CABOT_GLOBAL_LOCALIZER_RUN:=0}
@@ -473,6 +474,7 @@ if [ $cart_mapping -eq 1 ]; then
     # show mapping variables
     echo "MAPPING_USE_GNSS=$MAPPING_USE_GNSS"
     echo "MAPPING_RESOLUTION=$MAPPING_RESOLUTION"
+    echo "CABOT_ROSBAG_RECORD_CAMERA=$CABOT_ROSBAG_RECORD_CAMERA"
 
     # pre process config file
     bag_filename=${OUTPUT_PREFIX}_`date +%Y-%m-%d-%H-%M-%S`
@@ -516,6 +518,7 @@ return options/g' $configuration_directory_tmp/cartographer_2d_mapping.lua
           record_required:=true \
           record_points:=$record_points \
           compression_mode:=$CABOT_ROSBAG_COMPRESSION \
+          record_camera:=$CABOT_ROSBAG_RECORD_CAMERA \
           use_xsens:=${USE_XSENS:-true} \
           use_arduino:=${USE_ARDUINO:-false} \
           use_esp32:=${USE_ESP32:-false} \

--- a/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
+++ b/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
@@ -115,7 +115,9 @@ def generate_launch_description():
         if record_required.perform(context) == 'true':
             exclude_camera_topics = "(.*)/image_raw|(.*)/image_raw/(.*)"
             if is_truthy(context, record_camera):
-                exclude_camera_topics = "/.*/image_raw$"
+                # Match launch.sh same-bag camera recording: keep compressed color images,
+                # camera_info, and metadata, while dropping raw and depth image streams.
+                exclude_camera_topics = "/.*/image_raw$|^.*image_rect_raw.*$|^.*aligned_depth_to_color.*$"
             if record_points.perform(context) == 'true':
                 exclude_topics = f"/map|(.*)points_cropped|/pandar_packets|{exclude_camera_topics}"
             else:

--- a/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
+++ b/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
@@ -122,7 +122,7 @@ def generate_launch_description():
                 exclude_topics = f"/map|(.*)points_cropped|/pandar_packets|{exclude_camera_topics}"
             else:
                 exclude_topics = f"/map|/velodyne_points|(.*)points_cropped|/pandar_packets|{exclude_camera_topics}"
-            cmd.extend(['-a', '-x', f"'{exclude_topics}'"])
+            cmd.extend(['-a', '-x', exclude_topics])
         else:
             cmd.append('-a')
         saved_location_temp = []

--- a/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
+++ b/mf_localization_mapping/launch/realtime_cartographer_2d_VLP16.launch.py
@@ -76,6 +76,7 @@ def generate_launch_description():
     save_state_filename = LaunchConfiguration('save_state_filename')
     record_required = LaunchConfiguration('record_required')
     record_points = LaunchConfiguration('record_points')
+    record_camera = LaunchConfiguration('record_camera')
     compression_mode = LaunchConfiguration('compression_mode')
     configuration_basename = LaunchConfiguration('configuration_basename')
     # save_state_filename # todo
@@ -102,6 +103,9 @@ def generate_launch_description():
     fix_overwrite_time = LaunchConfiguration('fix_overwrite_time')
     interpolate_samples_by_trajectory = LaunchConfiguration('interpolate_samples_by_trajectory')
 
+    def is_truthy(context, launch_configuration):
+        return launch_configuration.perform(context).lower() in ('1', 'true', 'yes', 'on')
+
     def configure_ros2_bag_arguments(context, node):
         cmd = node.cmd.copy()
         if use_sim_time.perform(context) == 'true':
@@ -109,10 +113,14 @@ def generate_launch_description():
         if compression_mode.perform(context) != 'none':
             cmd.extend(['--compression-mode', compression_mode, '--compression-format', 'zstd'])
         if record_required.perform(context) == 'true':
+            exclude_camera_topics = "(.*)/image_raw|(.*)/image_raw/(.*)"
+            if is_truthy(context, record_camera):
+                exclude_camera_topics = "/.*/image_raw$"
             if record_points.perform(context) == 'true':
-                cmd.extend(['-a', '-x', "'/map|(.*)points_cropped|/pandar_packets|(.*)/image_raw|(.*)/image_raw/(.*)'"])
+                exclude_topics = f"/map|(.*)points_cropped|/pandar_packets|{exclude_camera_topics}"
             else:
-                cmd.extend(['-a', '-x', "'/map|/velodyne_points|(.*)points_cropped|/pandar_packets|(.*)/image_raw|(.*)/image_raw/(.*)'"])
+                exclude_topics = f"/map|/velodyne_points|(.*)points_cropped|/pandar_packets|{exclude_camera_topics}"
+            cmd.extend(['-a', '-x', f"'{exclude_topics}'"])
         else:
             cmd.append('-a')
         saved_location_temp = []
@@ -156,6 +164,7 @@ def generate_launch_description():
         DeclareLaunchArgument("load_state_filename", default_value=""),
         DeclareLaunchArgument("record_required", default_value="false"),
         DeclareLaunchArgument("record_points", default_value="false"),
+        DeclareLaunchArgument("record_camera", default_value="false"),
         DeclareLaunchArgument("compression_mode", default_value="message", description="{none,file,message} compress bag"),
 
         DeclareLaunchArgument("configuration_basename", default_value="cartographer_2d_mapping.lua"),


### PR DESCRIPTION
This PR adds a `record_camera` option to the mapping rosbag recorder.
When `CABOT_ROSBAG_RECORD_CAMERA=1` is set, mapping bags record camera-related topics, while avoiding raw and depth image streams that makes bags large.