### PR TITLE
support localization startup without saved state data

### DIFF
--- a/cabot_mf_localization/script/cabot_mf_localization.sh
+++ b/cabot_mf_localization/script/cabot_mf_localization.sh
@@ -420,6 +420,9 @@ fi
 if [ $cart_mapping -eq 1 ]; then
     if [[ $gazebo -eq 0 ]]; then
         imu_topic=/imu/data
+    else
+        # Gazebo GNSS fix messages can be published with status 0.
+        fix_status_threshold=0
     fi
 
     # switch lidar if specified
@@ -524,6 +527,7 @@ return options/g' $configuration_directory_tmp/cartographer_2d_mapping.lua
           use_esp32:=${USE_ESP32:-false} \
           use_velodyne:=${USE_VELODYNE:-true} \
           imu_topic:=${imu_topic} \
+          fix_status_threshold:=${fix_status_threshold} \
           use_sim_time:=$gazebo_bool \
           grid_resolution:=${MAPPING_RESOLUTION} \
           configuration_directory:=$configuration_directory_tmp \

--- a/mf_localization/mf_localization/cartographer_client.py
+++ b/mf_localization/mf_localization/cartographer_client.py
@@ -27,6 +27,7 @@ import tf_transformations
 from geometry_msgs.msg import Pose
 from dataclasses import dataclass
 
+from cartographer_ros_msgs.msg import StatusCode
 from cartographer_ros_msgs.msg import TrajectoryStates
 from cartographer_ros_msgs.srv import GetTrajectoryStates
 from cartographer_ros_msgs.srv import FinishTrajectory
@@ -73,6 +74,7 @@ class CartographerClient:
                  configuration_directory,
                  configuration_basename,
                  min_hist_count=1,
+                 fixed_frame_pose_constraints_min_count=2,
                  callback_group=MutuallyExclusiveCallbackGroup(),
                  ):
         # callback group accessing the same ros node
@@ -90,18 +92,24 @@ class CartographerClient:
 
         # constant
         self.relative_to_trajectory_id = 0
+        self.absolute_initial_pose_trajectory_id = -1
 
         # parameters
         self.min_hist_count = min_hist_count
+        self.fixed_frame_pose_constraints_min_count = fixed_frame_pose_constraints_min_count
 
         # states
         self.constraints_count = 0
+        self.fixed_frame_pose_constraints_count = 0
+        self.current_trajectory_id = None
 
         # memory
         self.trajectory_initial_pose = None
 
     def reset_states(self):
         self.constraints_count = 0
+        self.fixed_frame_pose_constraints_count = 0
+        self.current_trajectory_id = None
 
     def start_trajectory(self, pose: Pose, timeout_sec, max_retries):
         self.logger.info(F"wait for {self._start_trajectory.srv_name} service")
@@ -110,16 +118,26 @@ class CartographerClient:
         configuration_directory = self.configuration_directory
         configuration_basename = self.configuration_basename
         use_initial_pose = True
-        relative_to_trajectory_id = 0
+        relative_to_trajectory_id = self.relative_to_trajectory_id
 
-        # compute relative pose to trajectory initial pose
+        # Keep retrying until the reference trajectory becomes available.
+        # Once found, trajectory 0's initial pose is fixed and can be reused.
         if self.trajectory_initial_pose is None:
-            # trajectory query (for the first time)
-            self.trajectory_initial_pose = self.get_trajectory_initial_pose(timeout_sec=timeout_sec,
-                                                                            max_retries=max_retries)
+            self.trajectory_initial_pose = self.get_trajectory_initial_pose(
+                timeout_sec=timeout_sec,
+                max_retries=max_retries,
+            )
 
-        relative_pose: Pose = compute_relative_pose(self.trajectory_initial_pose, pose)
-        self.logger.info(F"converted initial_pose ({pose}) to relative_pose ({relative_pose}) on trajectory {relative_to_trajectory_id}")
+        if self.trajectory_initial_pose is not None:
+            relative_pose: Pose = compute_relative_pose(self.trajectory_initial_pose, pose)
+            self.logger.info(F"converted initial_pose ({pose}) to relative_pose ({relative_pose}) on trajectory {relative_to_trajectory_id}")
+        else:
+            relative_to_trajectory_id = self.absolute_initial_pose_trajectory_id
+            relative_pose = pose
+            self.logger.info(
+                F"start trajectory with absolute initial pose ({relative_pose}) "
+                F"because reference trajectory is not available. "
+                F"relative_to_trajectory_id={relative_to_trajectory_id}")
 
         self.logger.info("prepare request")
         req = StartTrajectory.Request(
@@ -140,10 +158,35 @@ class CartographerClient:
             raise e
         self.logger.info(F"start_trajectory response = {res2}")
         status_code = res2.status.code
+        if status_code == StatusCode.OK:
+            self.current_trajectory_id = res2.trajectory_id
+            self.fixed_frame_pose_constraints_count = 0
 
         return status_code
 
-    def get_trajectory_initial_pose(self, timeout_sec, max_retries=1) -> Pose:
+    def get_trajectory_initial_pose(self, timeout_sec, max_retries=1) -> Pose | None:
+
+        get_trajectory_states = self._get_trajectory_states
+        self.logger.info(F"wait for {get_trajectory_states.srv_name} service")
+        get_trajectory_states.wait_for_service()
+        try:
+            states_res: GetTrajectoryStates.Response = call_service(
+                get_trajectory_states,
+                GetTrajectoryStates.Request(),
+                timeout_sec=timeout_sec,
+                max_retries=max_retries,
+                logger=self.logger,
+            )
+        except (TimeoutError, Exception) as e:
+            self.logger.error(F"Failed to call get_trajectory_states. error={type(e).__name__}({e})")
+            raise e
+
+        trajectory_states = dict(zip(states_res.trajectory_states.trajectory_id,
+                                     states_res.trajectory_states.trajectory_state))
+        trajectory_state = trajectory_states.get(self.relative_to_trajectory_id)
+        if trajectory_state is None or trajectory_state == TrajectoryStates.DELETED:
+            self.logger.warn(F"trajectory {self.relative_to_trajectory_id} is not available.")
+            return None
 
         trajectory_query = self._trajectory_query
         self.logger.info(F"wait for {trajectory_query.srv_name} service")
@@ -162,6 +205,10 @@ class CartographerClient:
             self.logger.error(F"Failed to call trajectory_query. error={type(e).__name__}({e})")
             raise e
         trajectory = res.trajectory
+        if len(trajectory) == 0:
+            self.logger.warn(F"trajectory {self.relative_to_trajectory_id} is empty.")
+            return None
+
         trajectory_initial_pose: Pose = trajectory[0].pose  # PoseSamped -> Pose
 
         self.logger.info(F"trajectory {self.relative_to_trajectory_id} initial pose = {trajectory_initial_pose}")
@@ -223,21 +270,37 @@ class CartographerClient:
         return res
 
     def is_optimized(self, timeout_sec):
-        count = self.get_pose_graph_constraints_count(timeout_sec)
-        if count is None:
+        counts = self.get_scan_match_and_pose_graph_counts(timeout_sec)
+        if counts is None:
             return False
 
         # monitor mapping_2d_pose_graph_constraints -> inter_submap -> different trajectory to detect inter trajectory pose graph optimization
         # because this value is updated after running optimization
-        optimized = False
-        self.logger.info(f"inter_submap different trajectory constraints. count={count}")
-        # check if the number of constraints changed
-        if self.constraints_count != count:
-            self.constraints_count = count
-            if count >= self.min_hist_count:
-                optimized = True
-                self.logger.info("pose graph optimization detected.")
-        return optimized
+        count = counts.pose_graph_constraints_count
+        if count is not None:
+            self.logger.info(f"inter_submap different trajectory constraints. count={count}")
+            # check if the number of constraints changed
+            if self.constraints_count != count:
+                self.constraints_count = count
+                if count >= self.min_hist_count:
+                    self.logger.info("pose graph optimization detected by inter-submap constraints")
+                    return True
+
+        # monitor mapping_2d_pose_graph_fixed_frame_pose_constraints to detect fixed-frame-based optimization
+        fixed_frame_count = counts.fixed_frame_pose_constraints_count
+        if fixed_frame_count is not None:
+            threshold = self.fixed_frame_pose_constraints_min_count
+            self.logger.info(
+                f"fixed-frame pose constraints. trajectory_id={self.current_trajectory_id}, count={fixed_frame_count}, threshold={threshold}")
+            if self.fixed_frame_pose_constraints_count != fixed_frame_count:
+                self.fixed_frame_pose_constraints_count = fixed_frame_count
+                if fixed_frame_count >= threshold:
+                    self.logger.info(
+                        f"pose graph optimization detected by fixed-frame pose constraints. "
+                        f"trajectory_id={self.current_trajectory_id}, count={fixed_frame_count}, threshold={threshold}")
+                    return True
+
+        return False
 
     def get_pose_graph_constraints_count(self, timeout_sec):
         counts = self.get_scan_match_and_pose_graph_counts(timeout_sec)
@@ -255,6 +318,7 @@ class CartographerClient:
     class ScanMatchPoseGraphCounts:
         constraint_builder_count: float | None
         pose_graph_constraints_count: float | None
+        fixed_frame_pose_constraints_count: float | None
 
     def get_scan_match_and_pose_graph_counts(self, timeout_sec):
         res = self.read_metrics(timeout_sec)
@@ -269,6 +333,11 @@ class CartographerClient:
         constraint_builder_found = False
         pose_graph_total = 0.0
         pose_graph_found = False
+        current_trajectory_id = None
+        if self.current_trajectory_id is not None:
+            current_trajectory_id = str(self.current_trajectory_id)
+        fixed_frame_pose_graph_total = 0.0
+        fixed_frame_pose_graph_found = False
         for metric_family in res.metric_families:
             if metric_family.name in [
                     "mapping_constraints_constraint_builder_2d_constraints",
@@ -288,9 +357,20 @@ class CartographerClient:
                     if labels.get("tag") == "inter_submap" and labels.get("trajectory") == "different":
                         pose_graph_total += metric.value
                         pose_graph_found = True
-        if not (constraint_builder_found or pose_graph_found):
+            elif metric_family.name in [
+                    "mapping_2d_pose_graph_fixed_frame_pose_constraints",
+            ]:
+                if current_trajectory_id is None:
+                    continue
+                for metric in metric_family.metrics:
+                    labels = {label.key: label.value for label in metric.labels}
+                    if labels.get("trajectory_id") == current_trajectory_id:
+                        fixed_frame_pose_graph_total += metric.value
+                        fixed_frame_pose_graph_found = True
+        if not (constraint_builder_found or pose_graph_found or fixed_frame_pose_graph_found):
             return None
         return self.ScanMatchPoseGraphCounts(
             constraint_builder_count=constraint_builder_total if constraint_builder_found else None,
             pose_graph_constraints_count=pose_graph_total if pose_graph_found else None,
+            fixed_frame_pose_constraints_count=fixed_frame_pose_graph_total if fixed_frame_pose_graph_found else None,
         )

--- a/mf_localization/mf_localization/resource_utils.py
+++ b/mf_localization/mf_localization/resource_utils.py
@@ -26,6 +26,8 @@ import resource_retriever
 
 
 def get_filename(string):
+    if string is None:
+        return None
     if string.startswith("~/"):
         return os.path.expanduser(string)
     elif string.startswith("package://"):

--- a/mf_localization/script/multi_floor_manager.py
+++ b/mf_localization/script/multi_floor_manager.py
@@ -230,6 +230,7 @@ class FloorManager:
         self.ble_localizer = None
         self.wifi_localizer = None
         self.map_filename = ""
+        self.load_state_filename = None
 
         # publisher
         self.initialpose_pub = None
@@ -854,9 +855,9 @@ class MultiFloorManager:
             pose_stamped_msg.header = pose_with_covariance_stamped_msg.header
             pose_stamped_msg.pose = pose_with_covariance_stamped_msg.pose.pose
 
-            # detect area
-            x_area = [[pose_stamped_msg.pose.position.x, pose_stamped_msg.pose.position.y, float(target_floor)*self.area_floor_const]]  # [x,y,floor]
-            target_area = self.area_localizer.predict(x_area)[0]  # [area] area may change.
+            target_area = self.resolve_area_for_global_pose(pose_stamped_msg.pose, target_floor)
+            if target_area is None:
+                return StatusCode.CANCELLED
 
             if self.verbose:
                 self.logger.info(f"multi_floor_manager.initialize_with_global_pose: mode={target_mode}, floor={target_floor}, area={target_area}")
@@ -923,6 +924,18 @@ class MultiFloorManager:
 
             return status_code  # result of start_trajectory_with_pose
         return StatusCode.CANCELLED
+
+    def resolve_area_for_global_pose(self, pose, target_floor):
+        # fall back for no area_localizer
+        if self.area_localizer is None:
+            area_candidates = list(self.floor_manager_dict.get(target_floor, {}).keys())
+            if len(area_candidates) != 1:
+                self.logger.warn(f"Cannot determine area for floor {target_floor} without samples.")
+                return None
+            return area_candidates[0]
+
+        x_area = [[pose.position.x, pose.position.y, float(target_floor)*self.area_floor_const]]  # [x,y,floor]
+        return self.area_localizer.predict(x_area)[0]  # [area] area may change.
 
     def restart_floor(self, local_pose: Pose, target_floor=None, target_area=None, target_mode=None) -> int:
 
@@ -1011,6 +1024,9 @@ class MultiFloorManager:
             return
 
         if not self.altitude_floor_estimator.enabled():
+            return
+
+        if self.floor_height_mapper is None or self.area_localizer is None:
             return
 
         # get robot pose for floor height mapper
@@ -1139,6 +1155,9 @@ class MultiFloorManager:
             floor_localizer = self.ble_floor_localizer
         elif rss_type == RSSType.WiFi:
             floor_localizer = self.wifi_floor_localizer
+
+        if floor_localizer is None or self.area_localizer is None:
+            return
 
         loc = floor_localizer.predict(beacons)  # [[x,y,z,floor]]
 
@@ -1337,18 +1356,22 @@ class MultiFloorManager:
                 self.logger.warn(F"{e}")
                 return
 
-            # detect area switching
-            x_area = [[robot_pose.transform.translation.x, robot_pose.transform.translation.y, float(self.floor) * self.area_floor_const]]  # [x,y,floor]
+            if self.area_localizer is not None:
+                # detect area switching
+                x_area = [[robot_pose.transform.translation.x, robot_pose.transform.translation.y, float(self.floor) * self.area_floor_const]]  # [x,y,floor]
 
-            # find area candidates
-            neigh_dist, neigh_ind = self.area_localizer.kneighbors(x_area, n_neighbors=10)
-            area_candidates = self.Y_area[neigh_ind]
+                # find area candidates
+                neigh_dist, neigh_ind = self.area_localizer.kneighbors(x_area, n_neighbors=10)
+                area_candidates = self.Y_area[neigh_ind]
 
-            # switch area when the detected area is stable
-            unique_areas = np.unique(area_candidates)
-            if len(unique_areas) == 1:
-                area = unique_areas[0]
+                # switch area when the detected area is stable
+                unique_areas = np.unique(area_candidates)
+                if len(unique_areas) == 1:
+                    area = unique_areas[0]
+                else:
+                    area = self.area
             else:
+                # keep area when area_localizer is not available
                 area = self.area
 
             # if area change detected, switch trajectory
@@ -1956,7 +1979,7 @@ class MultiFloorManager:
 
         if self.floor is None:
             # estimate floor if enabled
-            if self.gnss_params.gnss_use_floor_estimation:
+            if self.gnss_params.gnss_use_floor_estimation and self.floor_height_mapper is not None:
                 near_floor_list = self.floor_height_mapper.get_floor_list([gnss_xy.x, gnss_xy.y],
                                                                           radius=self.gnss_params.gnss_floor_search_radius)
                 if len(near_floor_list) == 0:
@@ -2828,17 +2851,17 @@ if __name__ == "__main__":
                                 lng=map_dict["longitude"],
                                 rotate=map_dict["rotate"]
                                 )
-        load_state_filename = resource_utils.get_filename(map_dict["load_state_filename"])
-        samples_filename = resource_utils.get_filename(map_dict["samples_filename"])
+        load_state_filename = resource_utils.get_filename(map_dict.get("load_state_filename"))
+        samples_filename = resource_utils.get_filename(map_dict.get("samples_filename"))
         # rssi gain config
         rssi_gain = map_dict.get("rssi_gain", 0.0)
         rssi_gain_ble = map_dict.get("ble", {}).get("rssi_gain", rssi_gain)
         rssi_gain_wifi = map_dict.get("wifi", {}).get("rssi_gain", rssi_gain)
         # keep the original string without resource resolving. if not found in map_dict, use "".
-        map_filename = map_dict["map_filename"] if "map_filename" in map_dict else ""
+        map_filename = map_dict.get("map_filename") or ""
         environment = map_dict["environment"] if "environment" in map_dict else "indoor"
         use_gnss_adjust = map_dict["use_gnss_adjust"] if "use_gnss_adjust" in map_dict else False
-        min_hist_count = map_dict["min_hist_count"] if "min_hist_count" in map_dict else 1
+        cartographer_occupancy_grid_resolution = map_dict.get("cartographer_occupancy_grid", {}).get("resolution", 0.1)
 
         # warning
         if use_gnss_adjust:
@@ -2851,8 +2874,10 @@ if __name__ == "__main__":
 
         floor_set.add(floor)
 
-        with open(samples_filename, "rb") as f:
-            samples = orjson.loads(f.read())
+        samples = []
+        if samples_filename:
+            with open(samples_filename, "rb") as f:
+                samples = orjson.loads(f.read())
 
         # append additional information to the samples
         for s in samples:
@@ -2870,20 +2895,20 @@ if __name__ == "__main__":
 
         # BLE beacon localizer
         ble_localizer_floor = None
-        if multi_floor_manager.use_ble:
+        if multi_floor_manager.use_ble and samples_ble:
             # fit localizer for the floor
             ble_localizer_floor = create_wireless_rss_localizer(local_localizer_type, logger, n_neighbors=n_neighbors_local, min_beacons=min_beacons_local, rssi_offset=rssi_offset, n_strongest=n_strongest_local)
             ble_localizer_floor.fit(samples_ble)
-        else:
+        elif not multi_floor_manager.use_ble:
             samples_ble = []
 
         # WiFi localizer
         wifi_localizer_floor = None
-        if multi_floor_manager.use_wifi:
+        if multi_floor_manager.use_wifi and samples_wifi:
             # fit wifi localizer for the floor
             wifi_localizer_floor = create_wireless_rss_localizer(local_localizer_type, logger, n_neighbors=n_neighbors_local, min_beacons=min_beacons_local, n_strongest=n_strongest_local)
             wifi_localizer_floor.fit(samples_wifi)
-        else:
+        elif not multi_floor_manager.use_wifi:
             samples_wifi = []
 
         # run ros nodes
@@ -2923,6 +2948,17 @@ if __name__ == "__main__":
             executable1 = "cartographer_node"
 
             # run cartographer node
+            cartographer_arguments = [
+                "-configuration_directory", configuration_directory,
+                "-configuration_basename", tmp_configuration_basename,
+            ]
+            if load_state_filename:
+                cartographer_arguments.extend(["-load_state_filename", load_state_filename])
+            cartographer_arguments.extend([
+                "-start_trajectory_with_default_topics=false",
+                "--collect_metrics"
+            ])
+
             launch_service.include_launch_description(LaunchDescription([
                 LogInfo(msg=F"Launching cartographer node {namespace}"),
                 Node(
@@ -2936,19 +2972,30 @@ if __name__ == "__main__":
                                 ("odom", odom_topic_name),
                                 ("fix", "/"+namespace+fix_topic_name)],
                     output="both",
-                    arguments=[
-                        "-configuration_directory", configuration_directory,
-                        "-configuration_basename", tmp_configuration_basename,
-                        "-load_state_filename", load_state_filename,
-                        "-start_trajectory_with_default_topics=false",
-                        "--collect_metrics"
-                    ],
+                    arguments=cartographer_arguments,
                     parameters=[{
                         'use_sim_time': use_sim_time,
                         'qos_overrides': cartographer_qos_overrides_resolved
                     }]
                 )
             ]))
+
+            if not map_filename and mode == LocalizationMode.TRACK:
+                launch_service.include_launch_description(LaunchDescription([
+                    LogInfo(msg=F"Launching cartographer occupancy grid node {namespace}"),
+                    Node(
+                        package=package1,
+                        executable="cartographer_occupancy_grid_node",
+                        name="cartographer_occupancy_grid_node",
+                        namespace=namespace,
+                        remappings=[("map", "/" + node_id + "/map")],
+                        output="both",
+                        arguments=["-resolution", str(cartographer_occupancy_grid_resolution)],
+                        parameters=[{
+                            'use_sim_time': use_sim_time,
+                        }]
+                    )
+                ]))
 
             # create floor_manager
             floor_manager = FloorManager()
@@ -2966,6 +3013,7 @@ if __name__ == "__main__":
             floor_manager.node_id = node_id
             floor_manager.frame_id = frame_id
             floor_manager.map_filename = map_filename
+            floor_manager.load_state_filename = load_state_filename
             # publishers
             floor_manager.initialpose_pub = node.create_publisher(PoseWithCovarianceStamped, node_id+"/"+str(mode)+initialpose_topic_name, 10, callback_group=MutuallyExclusiveCallbackGroup())
             floor_manager.fix_pub = node.create_publisher(NavSatFix, node_id+"/"+str(mode)+fix_topic_name, 10, callback_group=MutuallyExclusiveCallbackGroup())
@@ -3008,6 +3056,8 @@ if __name__ == "__main__":
         floor = float(map_dict["floor"])
         area = int(map_dict["area"]) if "area" in map_dict else 0
         node_id = map_dict["node_id"]
+        min_hist_count = map_dict.get("min_hist_count", 1)
+        fixed_frame_pose_constraints_min_count = map_dict.get("fixed_frame_pose_constraints_min_count", 2)
 
         if map_dict["skip"]:
             continue
@@ -3019,18 +3069,19 @@ if __name__ == "__main__":
             floor_manager.cartographer_client = CartographerClient(node, logger, node_id, mode,
                                                                    floor_manager.configuration_directory,
                                                                    floor_manager.configuration_basename,
-                                                                   min_hist_count
+                                                                   min_hist_count,
+                                                                   fixed_frame_pose_constraints_min_count
                                                                    )
 
     multi_floor_manager.floor_list = list(floor_set)
 
     # a localizer to estimate floor
     # ble floor localizer
-    if multi_floor_manager.use_ble:
+    if multi_floor_manager.use_ble and samples_ble_global_all:
         multi_floor_manager.ble_floor_localizer = create_wireless_rss_localizer(floor_localizer_type, logger, n_neighbors=n_neighbors_floor, min_beacons=min_beacons_floor, rssi_offset=rssi_offset, n_strongest=n_strongest_floor)
         multi_floor_manager.ble_floor_localizer.fit(samples_ble_global_all)
     # wifi floor localizer
-    if multi_floor_manager.use_wifi:
+    if multi_floor_manager.use_wifi and samples_wifi_global_all:
         multi_floor_manager.wifi_floor_localizer = create_wireless_rss_localizer(floor_localizer_type, logger, n_neighbors=n_neighbors_floor, min_beacons=min_beacons_floor, n_strongest=n_strongest_floor)
         multi_floor_manager.wifi_floor_localizer.fit(samples_wifi_global_all)
 
@@ -3055,11 +3106,12 @@ if __name__ == "__main__":
         height = s["information"]["height"]
         effective_radius = s["information"]["effective_radius"]
         X_height_mapper.append([x_a, y_a, f_a, area, height, effective_radius])
-    if floor_height_mapper_config is None:
-        multi_floor_manager.floor_height_mapper = FloorHeightMapper(X_height_mapper, logger=logger,)
-    else:
-        logger.info(f"floor_height_mapper_config={floor_height_mapper_config}")
-        multi_floor_manager.floor_height_mapper = FloorHeightMapper(X_height_mapper, logger=logger, **floor_height_mapper_config)
+    if X_height_mapper:
+        if floor_height_mapper_config is None:
+            multi_floor_manager.floor_height_mapper = FloorHeightMapper(X_height_mapper, logger=logger,)
+        else:
+            logger.info(f"floor_height_mapper_config={floor_height_mapper_config}")
+            multi_floor_manager.floor_height_mapper = FloorHeightMapper(X_height_mapper, logger=logger, **floor_height_mapper_config)
 
     # area localizer
     X_area = []
@@ -3072,12 +3124,13 @@ if __name__ == "__main__":
         X_area.append([x_a, y_a, f_a])
         area = int(s["information"]["area"])
         Y_area.append(area)
-    from sklearn.neighbors import KNeighborsClassifier
-    area_classifier = KNeighborsClassifier(n_neighbors=1)
-    area_classifier.fit(X_area, Y_area)
-    multi_floor_manager.X_area = np.array(X_area)
-    multi_floor_manager.Y_area = np.array(Y_area)
-    multi_floor_manager.area_localizer = area_classifier
+    if X_area:
+        from sklearn.neighbors import KNeighborsClassifier
+        area_classifier = KNeighborsClassifier(n_neighbors=1)
+        area_classifier.fit(X_area, Y_area)
+        multi_floor_manager.X_area = np.array(X_area)
+        multi_floor_manager.Y_area = np.array(Y_area)
+        multi_floor_manager.area_localizer = area_classifier
 
     # define callback group accessing the state variables
     state_update_callback_group = MutuallyExclusiveCallbackGroup()

--- a/mf_localization/src/multi_floor_topic_proxy.cpp
+++ b/mf_localization/src/multi_floor_topic_proxy.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/int64.hpp"
@@ -33,6 +34,7 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
@@ -55,7 +57,8 @@ public:
   : Node("multi_floor_topic_proxy"),
     current_floor(0),
     current_area(0),
-    current_mode(0)
+    current_mode(0),
+    current_frame_id("")
   {
     std::string map_config_file = this->declare_parameter("map_config_file", "");
     bool verbose = this->declare_parameter("verbose", false);
@@ -70,21 +73,31 @@ public:
     std::string points2_topic_name = this->get_node_topics_interface()->resolve_topic_name("points2");
     std::string odom_topic_name = this->get_node_topics_interface()->resolve_topic_name("odom");
 
+    auto latched_qos = rclcpp::QoS(10).transient_local();
+
     auto map_list = config["map_list"];
+    std::unordered_map<int, int> floor_count;
     for (YAML::const_iterator it = map_list.begin(); it != map_list.end(); ++it) {
       YAML::Node map_dict = *it;
 
-      std::string node_id = map_dict["node_id"].as<std::string>();
+      int floor = static_cast<int>(map_dict["floor"].as<double>());
+      // Resolve missing area/node_id/frame_id with the same defaults as
+      // multi_floor_manager.py:extend_node_parameter_dictionary().
+      int area = resolve_area(map_dict, floor, floor_count);
+      std::string node_id = resolve_node_id(map_dict, floor, area);
+      std::string frame_id = resolve_frame_id(map_dict, node_id);
 
-      int floor = map_dict["floor"].as<int>();
-      int area = map_dict["area"].as<int>();
+      subscribe_map_if_needed(map_dict, node_id, frame_id, latched_qos);
+
       for (int mode = 0; mode < NUM_MODES; mode++) {
         auto mode_str = MODE_NAMES[mode];
 
         std::string key = getKey(floor, area, mode);
 
         FloorData floordata = {nullptr, nullptr, nullptr};
-        RCLCPP_INFO(this->get_logger(), "floor = %d, area = %d, mode=%d, key=%s", floor, area, mode, key.c_str());
+        RCLCPP_INFO(
+          this->get_logger(), "floor = %d, area = %d, mode=%d, key=%s, node_id=%s, frame_id=%s",
+          floor, area, mode, key.c_str(), node_id.c_str(), frame_id.c_str());
 
         floordata.imu_pub = this->create_publisher<sensor_msgs::msg::Imu>(node_id + "/" + mode_str + imu_topic_name, 1000);
         floordata.points_pub = this->create_publisher<sensor_msgs::msg::PointCloud2>(node_id + "/" + mode_str + points2_topic_name, 100);
@@ -96,10 +109,10 @@ public:
       }
     }
 
-    auto latched_qos = rclcpp::QoS(10).transient_local();
     current_floor_sub = this->create_subscription<std_msgs::msg::Int64>("current_floor", latched_qos, std::bind(&MultiFloorTopicProxy::current_floor_callback, this, _1));
     current_area_sub = this->create_subscription<std_msgs::msg::Int64>("current_area", latched_qos, std::bind(&MultiFloorTopicProxy::current_area_callback, this, _1));
     current_mode_sub = this->create_subscription<std_msgs::msg::Int64>("current_mode", latched_qos, std::bind(&MultiFloorTopicProxy::current_mode_callback, this, _1));
+    current_frame_sub = this->create_subscription<std_msgs::msg::String>("current_frame", latched_qos, std::bind(&MultiFloorTopicProxy::current_frame_callback, this, _1));
 
     rclcpp::SensorDataQoS sensor_qos;
     imu_sub = this->create_subscription<sensor_msgs::msg::Imu>("imu", sensor_qos, std::bind(&MultiFloorTopicProxy::imu_callback, this, _1));
@@ -136,6 +149,37 @@ public:
     RCLCPP_INFO(this->get_logger(), "floor=%d, area=%d, mode=%d", current_floor, current_area, current_mode);
   }
 
+  void current_frame_callback(const std_msgs::msg::String::SharedPtr msg)
+  {
+    this->current_frame_id = msg->data;
+    RCLCPP_INFO(this->get_logger(), "current_frame=%s", current_frame_id.c_str());
+    publish_cached_map(current_frame_id);
+  }
+
+  void map_callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg, const std::string & frame_id)
+  {
+    latest_maps[frame_id] = msg;
+    if (frame_id == current_frame_id) {
+      publish_map(*msg);
+    }
+  }
+
+  void publish_cached_map(const std::string & frame_id)
+  {
+    auto search = latest_maps.find(frame_id);
+    if (search == latest_maps.end()) {
+      return;
+    }
+    publish_map(*search->second);
+  }
+
+  void publish_map(const nav_msgs::msg::OccupancyGrid & msg)
+  {
+    if (!map_pub) {
+      return;
+    }
+    map_pub->publish(msg);
+  }
 
   void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg)
   {
@@ -189,21 +233,86 @@ public:
   }
 
 private:
+  int resolve_area(
+    const YAML::Node & map_dict, const int floor, std::unordered_map<int, int> & floor_count)
+  {
+    int area = 0;
+    if (map_dict["area"] && !map_dict["area"].IsNull()) {
+      area = map_dict["area"].as<int>();
+    } else {
+      area = floor_count[floor];
+    }
+    floor_count[floor] += 1;
+    return area;
+  }
+
+  std::string resolve_node_id(const YAML::Node & map_dict, const int floor, const int area)
+  {
+    if (map_dict["node_id"] && !map_dict["node_id"].IsNull()) {
+      return map_dict["node_id"].as<std::string>();
+    }
+
+    return "carto_" + std::to_string(floor) + "_" + std::to_string(area);
+  }
+
+  std::string resolve_frame_id(const YAML::Node & map_dict, const std::string & node_id)
+  {
+    if (map_dict["frame_id"] && !map_dict["frame_id"].IsNull()) {
+      return map_dict["frame_id"].as<std::string>();
+    }
+
+    return "map_" + node_id;
+  }
+
+  bool has_map_filename(const YAML::Node & map_dict) const
+  {
+    return map_dict["map_filename"] && !map_dict["map_filename"].IsNull() &&
+           !map_dict["map_filename"].as<std::string>().empty();
+  }
+
+  void subscribe_map_if_needed(
+    const YAML::Node & map_dict, const std::string & node_id, const std::string & frame_id,
+    const rclcpp::QoS & latched_qos)
+  {
+    if (has_map_filename(map_dict)) {
+      return;
+    }
+
+    std::string map_topic = "/" + node_id + "/map";
+    // Create /map publisher only when relaying maps without static map files.
+    if (!map_pub) {
+      map_pub = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/map", latched_qos);
+    }
+    map_subs[frame_id] = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
+      map_topic, latched_qos,
+      [this, frame_id](const nav_msgs::msg::OccupancyGrid::SharedPtr msg) {
+        this->map_callback(msg, frame_id);
+      });
+    RCLCPP_INFO(
+      this->get_logger(), "remap map topic source=%s, frame_id=%s",
+      map_topic.c_str(), frame_id.c_str());
+  }
+
   std::unordered_map<std::string, FloorData> floor_map;
 
   int current_floor;
   int current_area;
   int current_mode;
+  std::string current_frame_id;
 
   rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr current_floor_sub;
   rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr current_area_sub;
   rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr current_mode_sub;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr current_frame_sub;
 
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr points_sub;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub;
 
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr scan_matched_points_pub;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub;
+  std::unordered_map<std::string, rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr> map_subs;
+  std::unordered_map<std::string, nav_msgs::msg::OccupancyGrid::SharedPtr> latest_maps;
 };
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
### Summary

Support starting localization when saved localization state data are not available, while keeping the existing saved-state localization behavior

### Changes

- Missing assets
    - Allow `null` resource filenames (load_state_filename etc.).
    - Skip saved-state, samples, and static-map dependent setup when unavailable.
- cartographer node startup
    - Use absolute initial poses when reference trajectory 0 is unavailable.
-  Init-to-track state transition
    - In addition to scan-matching constraint count, use fixed-frame pose constraint count as a GNSS fallback.
- Map topic
    - Generate and relay occupancy grids only when no static map is loaded.

### Note

This change requires updating cartographer backend to
- https://github.com/CMU-cabot/cartographer_ros/commit/feedddc628d08d3811a0d45f1bf2bdc59f5158b1
- https://github.com/CMU-cabot/cartographer/commit/fae037002b9f3b072e38403cae0f3b02b158536b