### PR TITLE
Fix short NavCog path goal preservation

### DIFF
--- a/cabot_navigation2/plugins/navcog_path_util.cpp
+++ b/cabot_navigation2/plugins/navcog_path_util.cpp
@@ -157,6 +157,12 @@ nav_msgs::msg::Path adjustedPathByStart(
 
       last_pose = next_pose;
     }
+    if (next == path.poses.end()) {
+      ret.poses.clear();
+      ret.poses.push_back(start);
+      ret.poses.push_back(minpose);
+      next = minit + 1;
+    }
     for (; next < path.poses.end(); next++) {
       ret.poses.push_back(*next);
     }

--- a/cabot_navigation2/test/test_cabot_planner_util.cpp
+++ b/cabot_navigation2/test/test_cabot_planner_util.cpp
@@ -18,10 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <gtest/gtest.h>
+#include <cmath>
 #include <stdlib.h>
 
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+
 #include <cabot_navigation2/cabot_planner_util.hpp>
+#include <cabot_navigation2/navcog_path_util.hpp>
 
 namespace cabot_navigation2_test
 {
@@ -44,6 +48,22 @@ public:
 protected:
 };
 
+geometry_msgs::msg::PoseStamped makePose(double x, double y, double yaw)
+{
+  tf2::Quaternion q;
+  q.setRPY(0, 0, yaw);
+
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = "map";
+  pose.pose.position.x = x;
+  pose.pose.position.y = y;
+  pose.pose.orientation.x = q.x();
+  pose.pose.orientation.y = q.y();
+  pose.pose.orientation.z = q.z();
+  pose.pose.orientation.w = q.w();
+  return pose;
+}
+
 TEST_F(CabotPlannerUtilTest, ObstacleDistanceTest) {
   cabot_navigation2::Obstacle o1(0, 0, 254, 0, 0, false);
   cabot_navigation2::Obstacle o2(10, 10, 253, 0, 0, false);
@@ -62,6 +82,22 @@ TEST_F(CabotPlannerUtilTest, ObstacleDistanceTest) {
   printf("####%.2f\n", o2.distance(p2));
   printf("####%.2f\n", o2.distance(p3));
   printf("####%.2f\n", o2.distance(p4));
+}
+
+TEST_F(CabotPlannerUtilTest, SmoothStartKeepsShortPathGoal) {
+  nav_msgs::msg::Path navcog_path;
+  navcog_path.header.frame_id = "map";
+
+  auto path_yaw = std::atan2(-0.140, -2.715);
+  navcog_path.poses.push_back(makePose(26.329, -26.238, path_yaw));
+  navcog_path.poses.push_back(makePose(23.614, -26.378, path_yaw));
+
+  auto path = cabot_navigation2::normalizedPath(navcog_path, 0.05);
+  auto start = makePose(32.783, -29.231, path_yaw);
+
+  auto adjusted = cabot_navigation2::adjustedPathByStart(path, start, true);
+
+  EXPECT_LT(cabot_navigation2::distance(adjusted.poses.back(), path.poses.back()), 0.001);
 }
 
 }  // namespace cabot_navigation2_test

--- a/cabot_navigation2/test/test_cabot_planner_util.cpp
+++ b/cabot_navigation2/test/test_cabot_planner_util.cpp
@@ -18,10 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <cmath>
-#include <stdlib.h>
-
 #include <gtest/gtest.h>
+#include <math.h>
+#include <stdlib.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <cabot_navigation2/cabot_planner_util.hpp>
@@ -88,7 +87,7 @@ TEST_F(CabotPlannerUtilTest, SmoothStartKeepsShortPathGoal) {
   nav_msgs::msg::Path navcog_path;
   navcog_path.header.frame_id = "map";
 
-  auto path_yaw = std::atan2(-0.140, -2.715);
+  auto path_yaw = atan2(-0.140, -2.715);
   navcog_path.poses.push_back(makePose(26.329, -26.238, path_yaw));
   navcog_path.poses.push_back(makePose(23.614, -26.378, path_yaw));
 


### PR DESCRIPTION
## Summary

Fixes a short NavCog path adjustment case related to miraikan-research/TODO#1445.

When `adjustedPathByStart(..., smooth_start=true)` consumed the whole normalized path while smoothing the start, it could return only the synthesized smooth-start poses and drop the original path tail. For short straight paths this allowed the planned path to stop before the NavCog goal.

This change detects that full-consumption case and falls back to preserving the original remaining path from the nearest point, so the final NavCog goal remains in the adjusted path.

## Test Coverage

Added a C++ regression test in `cabot_navigation2` for the short-path goal preservation case.

Also pushed test-room scenario coverage to `CMU-cabot/cabot_sites_test` main:

- `55b61e1 Add test-room path regression scenarios`
- Adds a short standard-link goal regression scenario.
- Adds a standard-link midpoint scenario to ensure existing first-link midpoint behavior is preserved.

## Validation

Ran:

- `./build-workspace.sh -d -s navigation`
- `cabot_navigation2_test_cabot_planner_util --gtest_filter=CabotPlannerUtilTest.SmoothStartKeepsShortPathGoal`
- `DISPLAY=:0 ./launch.sh -s -d -S cabot_site_test_room -t -T tests -f 'test25_short_standard_link_goal|test26_navcog_first_standard_link_midpoint'`
- `DISPLAY=:0 ./launch.sh -s -d -S cabot_site_test_room -t -T tests`

The added `test25_short_standard_link_goal` and `test26_navcog_first_standard_link_midpoint` pass.

The full `tests.py` run still has existing failures in `test01_8_door_goal_and_manual_back`, `test01_9_change_speed`, and `test17_sharp_turn`. I rebuilt and reran those same three tests against the pre-change code, and they failed in the same places, so they do not appear to be regressions from this change.

## Authorship

Prepared by Codex.